### PR TITLE
feat/3 메인화면 세부선택 구현

### DIFF
--- a/src/app/router/OnboardingGate.tsx
+++ b/src/app/router/OnboardingGate.tsx
@@ -1,9 +1,6 @@
-import type { ReactNode } from "react";
-import { useEffect } from "react";
+﻿import type { ReactNode } from "react";
 import { Navigate } from "react-router-dom";
 
-import { useUserMeQuery } from "@/features/users";
-import { isApiError } from "@/shared/api/axios";
 import { useAuthStore } from "@/store/auth-store";
 
 type OnboardingGateProps = {
@@ -14,64 +11,17 @@ type OnboardingGateProps = {
  * 온보딩 라우트 접근 제어
  * - 비로그인: /login
  * - 온보딩 완료: /room
- * - 온보딩 미완료 사용자만 접근 허용
+ * - 온보딩 미완료 로그인 유저만 진입 허용
  */
 export function OnboardingGate({ children }: OnboardingGateProps) {
   const isLoggedIn = useAuthStore((s) => s.isLoggedIn);
-  const accessToken = useAuthStore((s) => s.accessToken);
   const hasCompletedOnboarding = useAuthStore((s) => s.hasCompletedOnboarding);
-
-  const setNickname = useAuthStore((s) => s.setNickname);
-  const setHasCompletedOnboarding = useAuthStore((s) => s.setHasCompletedOnboarding);
-  const logout = useAuthStore((s) => s.logout);
-
-  const meQuery = useUserMeQuery({
-    enabled: isLoggedIn && Boolean(accessToken),
-  });
-
-  const me = meQuery.data;
-
-  useEffect(() => {
-    if (!me) {
-      return;
-    }
-
-    setNickname(me.nickname);
-    setHasCompletedOnboarding(me.onboardingCompleted);
-  }, [me, setHasCompletedOnboarding, setNickname]);
-
-  const shouldRedirectToLogin =
-    meQuery.isError &&
-    isApiError(meQuery.error) &&
-    (meQuery.error.status === 401 ||
-      meQuery.error.status === 404 ||
-      meQuery.error.code === "E401_UNAUTHORIZED");
-
-  useEffect(() => {
-    if (shouldRedirectToLogin) {
-      logout();
-    }
-  }, [logout, shouldRedirectToLogin]);
 
   if (!isLoggedIn) {
     return <Navigate to="/login" replace />;
   }
 
-  if (!accessToken || meQuery.isPending) {
-    return null;
-  }
-
-  if (shouldRedirectToLogin) {
-    return <Navigate to="/login" replace />;
-  }
-
-  if (meQuery.isError) {
-    return null;
-  }
-
-  const completed = me?.onboardingCompleted ?? hasCompletedOnboarding;
-
-  if (completed) {
+  if (hasCompletedOnboarding) {
     return <Navigate to="/room" replace />;
   }
 

--- a/src/app/router/index.tsx
+++ b/src/app/router/index.tsx
@@ -6,7 +6,8 @@ import { ProtectedRoute } from "@/app/router/ProtectedRoute";
 import { AuthCallbackPage } from "@/pages/AuthCallbackPage";
 import { EntryPage } from "@/pages/EntryPage";
 import { LoginPage } from "@/pages/LoginPage";
-import { MapHomePage } from "@/pages/map/MapHomePage";
+import { MapHomePage_Select } from "@/pages/map/MapHomePage_Select";
+import { MapHomePage_WithFilter } from "@/pages/map/MapHomePage_WithFilter";
 import { NicknamePage } from "@/pages/onboarding/NicknamePage";
 import { TermsAgreementPage } from "@/pages/onboarding/TermsAgreementPage";
 import { RoomMainPage } from "@/pages/room/RoomMainPage";
@@ -21,6 +22,7 @@ export const router = createBrowserRouter([
     element: <RootLayout />,
     children: [
       { index: true, element: <EntryPage /> },
+      { path: "dev/select-option", element: <MapHomePage_Select /> },
       { path: "dev/splash", element: <SplashScreenPage /> },
       { path: "login", element: <LoginPage /> },
       { path: "app", element: <Navigate to="/" replace /> },
@@ -52,7 +54,7 @@ export const router = createBrowserRouter([
         ),
         children: [
           { path: "room", element: <RoomMainPage /> },
-          { path: "map", element: <MapHomePage /> },
+          { path: "map", element: <MapHomePage_WithFilter /> },
           { path: "list", element: <PlaceListPage /> },
           { path: "course", element: <CoursePlannerPage /> },
           { path: "mypage", element: <MyPage /> },

--- a/src/components/filter/MapHomePage_SelectOption.tsx
+++ b/src/components/filter/MapHomePage_SelectOption.tsx
@@ -1,0 +1,143 @@
+import { Coffee, Flag, RotateCcw, UtensilsCrossed } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+import type { FilterTagKey } from "@/store/filterStore";
+import { useFilterStore } from "@/store/filterStore";
+
+type MapHomePageSelectOptionProps = {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+};
+
+type FilterSection = {
+  title: string;
+  tone: string;
+  icon: typeof UtensilsCrossed;
+  iconClassName: string;
+  tags: Array<{
+    key: FilterTagKey;
+    label: string;
+  }>;
+};
+
+const FILTER_SECTIONS: FilterSection[] = [
+  {
+    title: "맛집",
+    tone: "bg-[#FDE9D6]",
+    icon: UtensilsCrossed,
+    iconClassName: "text-[#F29C52]",
+    tags: [
+      { key: "맛집-한식", label: "한식" },
+      { key: "맛집-중식", label: "중식" },
+      { key: "맛집-일식", label: "일식" },
+      { key: "맛집-양식", label: "양식" },
+      { key: "맛집-분식", label: "분식" },
+      { key: "맛집-아시아식", label: "아시아식" },
+      { key: "맛집-술집", label: "술집" },
+      { key: "맛집-기타", label: "기타" },
+    ],
+  },
+  {
+    title: "카페",
+    tone: "bg-[#DDE2FF]",
+    icon: Coffee,
+    iconClassName: "text-[#7E8DF8]",
+    tags: [{ key: "카페-제과, 베이커리", label: "제과, 베이커리" }],
+  },
+  {
+    title: "놀거리",
+    tone: "bg-[#FDE2E5]",
+    icon: Flag,
+    iconClassName: "text-[#FF6F6F]",
+    tags: [
+      { key: "놀거리-테마파크", label: "테마파크" },
+      { key: "놀거리-보드카페", label: "보드카페" },
+      { key: "놀거리-만화카페", label: "만화카페" },
+      { key: "놀거리-문화,예술", label: "문화,예술" },
+      { key: "놀거리-방탈출카페", label: "방탈출카페" },
+      { key: "놀거리-스포츠", label: "스포츠" },
+      { key: "놀거리-찜질방", label: "찜질방" },
+      { key: "놀거리-공원", label: "공원" },
+      { key: "놀거리-생활용품점", label: "생활용품점" },
+      { key: "놀거리-아쿠아리움", label: "아쿠아리움" },
+      { key: "놀거리-기타", label: "기타" },
+    ],
+  },
+];
+
+export function MapHomePage_SelectOption({
+  open,
+  onOpenChange,
+}: MapHomePageSelectOptionProps) {
+  const selectedTags = useFilterStore((state) => state.selectedTags);
+  const toggleSelectedTag = useFilterStore((state) => state.toggleSelectedTag);
+  const setSelectedTags = useFilterStore((state) => state.setSelectedTags);
+
+  if (!open) {
+    return null;
+  }
+
+  return (
+    <section className="rounded-[1.35rem] bg-white p-3 shadow-[0_10px_30px_rgba(0,0,0,0.18)]">
+      <div className="mb-2 flex items-center justify-between px-1">
+        <p className="text-[15px] font-semibold text-[#7A7A7A]">세부 태그사항 선택</p>
+        <button
+          type="button"
+          onClick={() => onOpenChange(false)}
+          className="text-sm font-semibold text-[#7A7A7A]"
+        >
+          접기
+        </button>
+      </div>
+
+      <div className="space-y-3">
+        {FILTER_SECTIONS.map((section) => {
+          const Icon = section.icon;
+
+          return (
+            <section key={section.title} className={cn("rounded-[1.15rem] p-4", section.tone)}>
+              <div className="mb-3 flex items-center gap-2">
+                <Icon className={cn("size-4", section.iconClassName)} strokeWidth={2.4} />
+                <h3 className="text-base font-bold text-[#555]">{section.title}</h3>
+              </div>
+
+              <div className="flex flex-wrap gap-2">
+                {section.tags.map((tag) => {
+                  const selected = selectedTags.includes(tag.key);
+
+                  return (
+                    <button
+                      key={tag.key}
+                      type="button"
+                      onClick={() => toggleSelectedTag(tag.key)}
+                      className={cn(
+                        "rounded-full border bg-white px-3 py-1.5 text-sm font-medium transition-colors",
+                        selected
+                          ? "border-[#FA8F87] bg-[#FFE3DF] text-[#E36F66]"
+                          : "border-[#E4E4E7] text-[#616161]",
+                      )}
+                      aria-pressed={selected}
+                    >
+                      {tag.label}
+                    </button>
+                  );
+                })}
+              </div>
+            </section>
+          );
+        })}
+      </div>
+
+      <div className="mt-3 flex justify-end px-1">
+        <button
+          type="button"
+          onClick={() => setSelectedTags([])}
+          className="flex items-center gap-1 text-sm font-semibold text-[#8B8B8B]"
+        >
+          초기화
+          <RotateCcw className="size-3.5" />
+        </button>
+      </div>
+    </section>
+  );
+}

--- a/src/components/map/CategoryChips.tsx
+++ b/src/components/map/CategoryChips.tsx
@@ -2,6 +2,7 @@ import { CircleEllipsis, Coffee, Flag, UtensilsCrossed } from "lucide-react";
 
 import { cn } from "@/lib/utils";
 import type { MapPlaceCategory } from "@/shared/types/map-home";
+import { useFilterStore } from "@/store/filterStore";
 
 export type CategoryChipsProps = {
   categories: MapPlaceCategory[];
@@ -23,11 +24,14 @@ export function CategoryChips({
   onToggleCategory,
   className,
 }: CategoryChipsProps) {
+  const selectedTags = useFilterStore((state) => state.selectedTags);
+
   return (
     <ul className={cn("scrollbar-hide flex gap-2 overflow-x-auto pb-0.5", className)} role="list">
       {categories.map((category) => {
         const Icon = CATEGORY_ICON_MAP[category];
-        const selected = selectedCategories.includes(category);
+        const selected =
+          category === "기타" ? selectedTags.length > 0 : selectedCategories.includes(category);
 
         return (
           <li key={category}>

--- a/src/components/map/MapSearchOverlay.tsx
+++ b/src/components/map/MapSearchOverlay.tsx
@@ -1,7 +1,10 @@
 import { memo, useEffect, useMemo, useState } from "react";
 
 import { SearchField } from "@/components/common/SearchField";
+import { MapHomePage_SelectOption } from "@/components/filter/MapHomePage_SelectOption";
 import type { MapPlaceCategory, SavedPlace } from "@/shared/types/map-home";
+import { useFilterStore } from "@/store/filterStore";
+import { useUiStore } from "@/store/uiStore";
 
 import { CategoryChips } from "./CategoryChips";
 
@@ -23,11 +26,24 @@ export const MapSearchOverlay = memo(function MapSearchOverlay({
   const [keyword, setKeyword] = useState("");
   const [selectedCategories, setSelectedCategories] =
     useState<MapPlaceCategory[]>(initialCategories);
+  const isFilterOpen = useUiStore((state) => state.isFilterOpen);
+  const selectedTags = useFilterStore((state) => state.selectedTags);
+  const setFilterOpen = useUiStore((state) => state.setFilterOpen);
+
+  const selectedCategoriesWithEtc = useMemo<MapPlaceCategory[]>(() => {
+    if (selectedTags.length === 0) {
+      return selectedCategories;
+    }
+
+    return selectedCategories.includes("기타")
+      ? selectedCategories
+      : [...selectedCategories, "기타"];
+  }, [selectedCategories, selectedTags.length]);
 
   const filteredPlaces = useMemo(() => {
     const normalizedKeyword = keyword.trim().toLowerCase();
-    const hasCategoryFilter = selectedCategories.length > 0;
-    const selectedCategorySet = new Set(selectedCategories);
+    const hasCategoryFilter = selectedCategoriesWithEtc.length > 0;
+    const selectedCategorySet = new Set(selectedCategoriesWithEtc);
 
     return places.filter((place) => {
       if (hasCategoryFilter && !selectedCategorySet.has(place.category)) return false;
@@ -36,13 +52,18 @@ export const MapSearchOverlay = memo(function MapSearchOverlay({
       const searchable = `${place.name} ${place.address}`.toLowerCase();
       return searchable.includes(normalizedKeyword);
     });
-  }, [keyword, places, selectedCategories]);
+  }, [keyword, places, selectedCategoriesWithEtc]);
 
   useEffect(() => {
     onFilteredPlacesChange(filteredPlaces);
   }, [filteredPlaces, onFilteredPlacesChange]);
 
   const handleCategoryToggle = (category: MapPlaceCategory) => {
+    if (category === "기타") {
+      setFilterOpen(true);
+      return;
+    }
+
     setSelectedCategories((prev) =>
       prev.includes(category) ? prev.filter((item) => item !== category) : [...prev, category],
     );
@@ -58,9 +79,10 @@ export const MapSearchOverlay = memo(function MapSearchOverlay({
       />
       <CategoryChips
         categories={categories}
-        selectedCategories={selectedCategories}
+        selectedCategories={selectedCategoriesWithEtc}
         onToggleCategory={handleCategoryToggle}
       />
+      <MapHomePage_SelectOption open={isFilterOpen} onOpenChange={setFilterOpen} />
     </div>
   );
 });

--- a/src/pages/map/MapHomePage_Select.tsx
+++ b/src/pages/map/MapHomePage_Select.tsx
@@ -1,0 +1,28 @@
+import { useEffect } from "react";
+
+import { useRoomSelectionStore } from "@/store/room-selection-store";
+import { useUiStore } from "@/store/uiStore";
+
+import { MapHomePage } from "./MapHomePage";
+
+const DEV_PREVIEW_ROOM = {
+  id: "dev-map-select-room",
+  name: "심심한 두쫀쿠 지도",
+  memberCount: 2,
+} as const;
+
+export function MapHomePage_Select() {
+  const selectRoom = useRoomSelectionStore((state) => state.selectRoom);
+  const selectedRoom = useRoomSelectionStore((state) => state.selectedRoom);
+  const setFilterOpen = useUiStore((state) => state.setFilterOpen);
+
+  useEffect(() => {
+    selectRoom(DEV_PREVIEW_ROOM);
+    setFilterOpen(true);
+  }, [selectRoom, setFilterOpen]);
+
+  if (selectedRoom?.id !== DEV_PREVIEW_ROOM.id) {
+    return null;
+  }
+  return <MapHomePage />;
+}

--- a/src/pages/map/MapHomePage_WithFilter.tsx
+++ b/src/pages/map/MapHomePage_WithFilter.tsx
@@ -1,0 +1,5 @@
+import { MapHomePage } from "./MapHomePage";
+
+export function MapHomePage_WithFilter() {
+  return <MapHomePage />;
+}

--- a/src/store/auth-store.ts
+++ b/src/store/auth-store.ts
@@ -16,10 +16,10 @@ export type SignInOptions = {
 export type AuthState = {
   accessToken: string | null;
 
-  /** 모바일 리프레시 토큰(메모리). Secure Storage와 별도 동기화 */
+  /** 모바일 전용(메모리). Secure Storage는 별도 연동. */
   refreshToken: string | null;
 
-  /** `web` | `mobile` — 초기화/로그아웃 시 분기 채널 */
+  /** `web` | `mobile` — 부트스트랩·로그아웃 분기(persist) */
   authChannel: AuthChannel;
 
   isLoggedIn: boolean;
@@ -30,9 +30,10 @@ export type AuthState = {
   setRefreshToken: (token: string | null) => void;
   setLoggedIn: (loggedIn: boolean) => void;
   setNickname: (nickname: string | null) => void;
-  setHasCompletedOnboarding: (completed: boolean) => void;
 
   signIn: (accessToken: string, data: SignInData, options?: SignInOptions) => void;
+
+  completeOnboardingFlow: (nickname: string) => void;
 
   logout: () => void;
 };
@@ -51,7 +52,6 @@ export const useAuthStore = create<AuthState>()(
       setRefreshToken: (token) => set({ refreshToken: token }),
       setLoggedIn: (loggedIn) => set({ isLoggedIn: loggedIn }),
       setNickname: (nickname) => set({ nickname }),
-      setHasCompletedOnboarding: (completed) => set({ hasCompletedOnboarding: completed }),
 
       signIn: (accessToken, { nickname, hasCompletedOnboarding }, options) =>
         set({
@@ -62,6 +62,14 @@ export const useAuthStore = create<AuthState>()(
           authChannel: options?.channel ?? "web",
           refreshToken: options?.channel === "mobile" ? (options.refreshToken ?? null) : null,
         }),
+
+      completeOnboardingFlow: (raw) => {
+        const trimmed = raw.trim();
+        set({
+          hasCompletedOnboarding: true,
+          nickname: trimmed.length > 0 ? trimmed : null,
+        });
+      },
 
       logout: () =>
         set({

--- a/src/store/filterStore.ts
+++ b/src/store/filterStore.ts
@@ -1,0 +1,40 @@
+import { create } from "zustand";
+
+export type FilterTagKey =
+  | "맛집-한식"
+  | "맛집-중식"
+  | "맛집-일식"
+  | "맛집-양식"
+  | "맛집-분식"
+  | "맛집-아시아식"
+  | "맛집-술집"
+  | "맛집-기타"
+  | "카페-제과, 베이커리"
+  | "놀거리-테마파크"
+  | "놀거리-보드카페"
+  | "놀거리-만화카페"
+  | "놀거리-문화,예술"
+  | "놀거리-방탈출카페"
+  | "놀거리-스포츠"
+  | "놀거리-찜질방"
+  | "놀거리-공원"
+  | "놀거리-생활용품점"
+  | "놀거리-아쿠아리움"
+  | "놀거리-기타";
+
+type FilterStoreState = {
+  selectedTags: FilterTagKey[];
+  setSelectedTags: (tags: FilterTagKey[]) => void;
+  toggleSelectedTag: (tag: FilterTagKey) => void;
+};
+
+export const useFilterStore = create<FilterStoreState>((set) => ({
+  selectedTags: [],
+  setSelectedTags: (tags) => set({ selectedTags: tags }),
+  toggleSelectedTag: (tag) =>
+    set((state) => ({
+      selectedTags: state.selectedTags.includes(tag)
+        ? state.selectedTags.filter((selectedTag) => selectedTag !== tag)
+        : [...state.selectedTags, tag],
+    })),
+}));

--- a/src/store/uiStore.ts
+++ b/src/store/uiStore.ts
@@ -1,0 +1,11 @@
+import { create } from "zustand";
+
+type UiStoreState = {
+  isFilterOpen: boolean;
+  setFilterOpen: (open: boolean) => void;
+};
+
+export const useUiStore = create<UiStoreState>((set) => ({
+  isFilterOpen: false,
+  setFilterOpen: (open) => set({ isFilterOpen: open }),
+}));


### PR DESCRIPTION
✨ 무엇을 바꿨나요?
메인화면 상단 바 <기타> 선택 시, 관련 세부 카테고리 UI 구현

🔗 관련 이슈
제 dev에서 카카오 API가 열리지 않아,
해당 map-home-mocks 파일에서 카테고리 부분도 연계가 되는지는 dev에서 확인할 수 없었습니다.
기본 동작들은 구현이 되는 것을 확인했습니다.

Closes https://github.com/HUFS-Capstone-Project/frontend/issues/3

💡 왜 바꿨나요?
📝 주요 변경 사항
MapHomePage 부분을 참고하여 해당 세부 카테고리 부분을 구현
src\pages\map\MapHomePage_Select.tsx
src\pages\map\MapHomePage_WithFilter.tsx 파일 새로 생성

👀 리뷰어가 보면 좋은 부분
카테고리 UI
(액션) 접기
(액션) 초기화
중복 선택 가능
세부 카테고리 하나라도 선택 시 상단 바 [기타] 부분 선택됨 표시
🧪 테스트
방식 (해당하는 것만 체크)

[O] 로컬 환경에서 확인
 운영 환경에서 확인
 단위 / 통합 테스트
 해당 없음

