### PR TITLE
Feature/course planner UI

### DIFF
--- a/src/app/router/index.tsx
+++ b/src/app/router/index.tsx
@@ -22,6 +22,7 @@ export const router = createBrowserRouter([
     children: [
       { index: true, element: <EntryPage /> },
       { path: "dev/splash", element: <SplashScreenPage /> },
+      { path: "dev/course", element: <CoursePlannerPage skipRoomGuard /> },
       { path: "login", element: <LoginPage /> },
       { path: "app", element: <Navigate to="/" replace /> },
       {
@@ -61,3 +62,5 @@ export const router = createBrowserRouter([
     ],
   },
 ]);
+
+

--- a/src/components/course-planner/CourseEditPanel.tsx
+++ b/src/components/course-planner/CourseEditPanel.tsx
@@ -1,0 +1,200 @@
+﻿import { ArrowDown, ArrowUp, ChevronLeft, Trash2 } from "lucide-react";
+import { useState } from "react";
+
+import type { CourseStop } from "@/components/course-planner/CoursePlaceInfoPanel";
+import { cn } from "@/lib/utils";
+
+type CourseEditPanelProps = {
+  title: string;
+  stops: CourseStop[];
+  onBack: () => void;
+  onSave: (nextTitle: string, nextStops: CourseStop[]) => void;
+};
+
+export function CourseEditPanel({ title, stops, onBack, onSave }: CourseEditPanelProps) {
+  const [draftTitle, setDraftTitle] = useState(title);
+  const [draftStops, setDraftStops] = useState(stops);
+  const [deleteTargetId, setDeleteTargetId] = useState<string | null>(null);
+  const [isSaveConfirmOpen, setIsSaveConfirmOpen] = useState(false);
+
+  const deleteTarget = draftStops.find((stop) => stop.id === deleteTargetId);
+
+  const moveStop = (fromIndex: number, direction: "up" | "down") => {
+    const toIndex = direction === "up" ? fromIndex - 1 : fromIndex + 1;
+    if (toIndex < 0 || toIndex >= draftStops.length) return;
+
+    const nextStops = [...draftStops];
+    const [movedStop] = nextStops.splice(fromIndex, 1);
+    nextStops.splice(toIndex, 0, movedStop);
+    setDraftStops(nextStops);
+  };
+
+  const handleDeleteStop = () => {
+    if (!deleteTargetId) return;
+    setDraftStops((current) => current.filter((stop) => stop.id !== deleteTargetId));
+    setDeleteTargetId(null);
+  };
+
+  const handleConfirmSave = () => {
+    onSave(draftTitle.trim() || title, draftStops);
+  };
+
+  return (
+    <section className="relative z-20 -mt-9 rounded-t-[28px] bg-white px-4 pb-7 pt-5 shadow-[0_-16px_40px_rgba(15,23,42,0.08)]">
+      <div className="mx-auto mb-4 h-1 w-14 rounded-full bg-[#d9d9d9]" />
+
+      <header className="flex items-center gap-2">
+        <button
+          type="button"
+          onClick={onBack}
+          className="inline-flex size-8 items-center justify-center rounded-full text-[#52525b] transition-colors hover:bg-[#f4f4f5] focus-visible:outline-none focus-visible:ring-3 focus-visible:ring-ring/50"
+          aria-label="코스 상세로 돌아가기"
+        >
+          <ChevronLeft className="size-4" aria-hidden />
+        </button>
+        <h1 className="text-sm font-bold text-[#171717]">코스 편집</h1>
+      </header>
+
+      <label className="mt-5 grid gap-2">
+        <span className="text-xs font-semibold text-[#52525b]">코스명</span>
+        <input
+          value={draftTitle}
+          onChange={(event) => setDraftTitle(event.target.value)}
+          className="h-10 rounded-md border border-[#d4d4d8] bg-white px-3 text-sm font-semibold text-[#171717] outline-none transition-colors focus:border-[#f06f6b] focus:ring-3 focus:ring-[#f06f6b]/20"
+          aria-label="코스명"
+        />
+      </label>
+
+      <div className="mt-5 grid gap-3">
+        <div className="flex items-center justify-between">
+          <h2 className="text-xs font-semibold text-[#52525b]">장소 순서</h2>
+          <span className="text-[0.7rem] text-[#9ca3af]">위/아래로 순서를 바꿀 수 있어요</span>
+        </div>
+
+        {draftStops.map((stop, index) => (
+          <article
+            key={stop.id}
+            className="grid grid-cols-[1.5rem_1fr_auto] items-center gap-3 rounded-xl border border-[#eeeeee] bg-white px-3 py-3"
+          >
+            <span className="flex size-6 items-center justify-center rounded-full bg-[#fff0ee] text-xs font-bold text-[#f06f6b]">
+              {index + 1}
+            </span>
+
+            <div className="min-w-0">
+              <h3 className="truncate text-sm font-semibold text-[#171717]">{stop.name}</h3>
+              <p className="mt-1 truncate text-xs text-[#71717a]">{stop.address}</p>
+            </div>
+
+            <div className="flex items-center gap-1">
+              <button
+                type="button"
+                onClick={() => moveStop(index, "up")}
+                disabled={index === 0}
+                className="inline-flex size-8 items-center justify-center rounded-full text-[#52525b] transition-colors hover:bg-[#f4f4f5] disabled:text-[#d4d4d8]"
+                aria-label={`${stop.name} 위로 이동`}
+              >
+                <ArrowUp className="size-4" aria-hidden />
+              </button>
+              <button
+                type="button"
+                onClick={() => moveStop(index, "down")}
+                disabled={index === draftStops.length - 1}
+                className="inline-flex size-8 items-center justify-center rounded-full text-[#52525b] transition-colors hover:bg-[#f4f4f5] disabled:text-[#d4d4d8]"
+                aria-label={`${stop.name} 아래로 이동`}
+              >
+                <ArrowDown className="size-4" aria-hidden />
+              </button>
+              <button
+                type="button"
+                onClick={() => setDeleteTargetId(stop.id)}
+                className="inline-flex size-8 items-center justify-center rounded-full text-[#ef4444] transition-colors hover:bg-[#fef2f2]"
+                aria-label={`${stop.name} 삭제`}
+              >
+                <Trash2 className="size-4" aria-hidden />
+              </button>
+            </div>
+          </article>
+        ))}
+      </div>
+
+      <button
+        type="button"
+        onClick={() => setIsSaveConfirmOpen(true)}
+        className={cn(
+          "mt-5 inline-flex h-11 w-full items-center justify-center rounded-lg text-sm font-semibold text-white transition-colors focus-visible:outline-none focus-visible:ring-3 focus-visible:ring-ring/50",
+          draftStops.length > 0 ? "bg-[#f06f6b] hover:bg-[#e86460]" : "bg-[#d4d4d8]",
+        )}
+        disabled={draftStops.length === 0}
+      >
+        데이트코스 저장하기
+      </button>
+
+      {deleteTarget ? (
+        <ConfirmDialog
+          title="이 장소를 삭제하시겠어요?"
+          description={deleteTarget.name}
+          confirmLabel="삭제"
+          confirmClassName="text-[#ef4444]"
+          onCancel={() => setDeleteTargetId(null)}
+          onConfirm={handleDeleteStop}
+        />
+      ) : null}
+
+      {isSaveConfirmOpen ? (
+        <ConfirmDialog
+          title="변경한 코스를 저장할까요?"
+          description="저장하면 지금 편집한 코스명과 장소 순서가 반영됩니다."
+          confirmLabel="저장"
+          confirmClassName="text-[#f06f6b]"
+          onCancel={() => setIsSaveConfirmOpen(false)}
+          onConfirm={handleConfirmSave}
+        />
+      ) : null}
+    </section>
+  );
+}
+
+type ConfirmDialogProps = {
+  title: string;
+  description: string;
+  confirmLabel: string;
+  confirmClassName: string;
+  onCancel: () => void;
+  onConfirm: () => void;
+};
+
+function ConfirmDialog({
+  title,
+  description,
+  confirmLabel,
+  confirmClassName,
+  onCancel,
+  onConfirm,
+}: ConfirmDialogProps) {
+  return (
+    <div className="absolute inset-0 z-30 flex items-start justify-center bg-black/35 px-8 pt-28">
+      <div className="w-full max-w-[250px] overflow-hidden rounded-xl bg-white text-center shadow-xl">
+        <div className="px-4 py-5">
+          <p className="text-sm font-semibold text-[#171717]">{title}</p>
+          <p className="mt-1 text-xs leading-5 text-[#71717a]">{description}</p>
+        </div>
+        <div className="grid grid-cols-2 border-t border-[#eeeeee]">
+          <button
+            type="button"
+            onClick={onCancel}
+            className="h-11 border-r border-[#eeeeee] text-sm font-medium text-[#2563eb]"
+          >
+            취소
+          </button>
+          <button
+            type="button"
+            onClick={onConfirm}
+            className={cn("h-11 text-sm font-semibold", confirmClassName)}
+          >
+            {confirmLabel}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/course-planner/CourseGenerationLoadingPanel.tsx
+++ b/src/components/course-planner/CourseGenerationLoadingPanel.tsx
@@ -1,0 +1,18 @@
+﻿import { Loader2 } from "lucide-react";
+
+export function CourseGenerationLoadingPanel() {
+  return (
+    <section className="relative z-20 -mt-9 min-h-[420px] rounded-t-[28px] bg-white px-4 pb-7 pt-8 shadow-[0_-16px_40px_rgba(15,23,42,0.08)]">
+      <div className="mx-auto mb-12 h-1 w-14 rounded-full bg-[#d9d9d9]" />
+
+      <div className="flex min-h-[250px] flex-col items-center justify-center text-center">
+        <p className="text-base font-semibold leading-7 text-[#171717]">
+          실심 한 두줄 방을 위한
+          <br />
+          맞춤 데이트코스를 생성하고 있어요
+        </p>
+        <Loader2 className="mt-8 size-7 animate-spin text-[#9ca3af]" aria-label="데이트코스 생성 중" />
+      </div>
+    </section>
+  );
+}

--- a/src/components/course-planner/CoursePlaceInfoPanel.tsx
+++ b/src/components/course-planner/CoursePlaceInfoPanel.tsx
@@ -1,0 +1,98 @@
+﻿import { ChevronDown, ChevronLeft, MapPin, Pencil, PersonStanding } from "lucide-react";
+
+export type CourseStop = {
+  id: string;
+  name: string;
+  address: string;
+  category: string;
+  walkingTime: string;
+  hours: string;
+};
+
+type CoursePlaceInfoPanelProps = {
+  courseTitle: string;
+  stops: CourseStop[];
+  onBack: () => void;
+  onEdit: () => void;
+};
+
+export function CoursePlaceInfoPanel({ courseTitle, stops, onBack, onEdit }: CoursePlaceInfoPanelProps) {
+  const primaryStop = stops[0];
+
+  return (
+    <section className="relative z-20 -mt-9 rounded-t-[28px] bg-white px-4 pb-7 pt-5 shadow-[0_-16px_40px_rgba(15,23,42,0.08)]">
+      <div className="mx-auto mb-4 h-1 w-14 rounded-full bg-[#d9d9d9]" />
+
+      <header className="flex items-center gap-2">
+        <button
+          type="button"
+          onClick={onBack}
+          className="inline-flex size-8 items-center justify-center rounded-full text-[#52525b] transition-colors hover:bg-[#f4f4f5] focus-visible:outline-none focus-visible:ring-3 focus-visible:ring-ring/50"
+          aria-label="코스 목록으로 돌아가기"
+        >
+          <ChevronLeft className="size-4" aria-hidden />
+        </button>
+        <h1 className="min-w-0 flex-1 truncate text-sm font-bold text-[#171717]">{courseTitle}</h1>
+        <button
+          type="button"
+          onClick={onEdit}
+          className="inline-flex size-8 items-center justify-center rounded-full text-[#71717a] transition-colors hover:bg-[#f4f4f5] focus-visible:outline-none focus-visible:ring-3 focus-visible:ring-ring/50"
+          aria-label="코스 편집하기"
+        >
+          <Pencil className="size-3.5" aria-hidden />
+        </button>
+      </header>
+
+      <div className="mt-5 grid grid-cols-[1.25rem_1fr] gap-x-3">
+        <div className="flex flex-col items-center pt-1" aria-hidden>
+          <span className="size-3 rounded-full border-2 border-[#737373] bg-white" />
+          <span className="mt-1 min-h-36 flex-1 border-l border-dashed border-[#a3a3a3]" />
+          <span className="size-3 rounded-full border-2 border-[#737373] bg-white" />
+        </div>
+
+        <div className="grid gap-5 pb-5">
+          {stops.map((stop) => (
+            <article key={stop.id}>
+              <h2 className="text-sm font-bold text-[#171717]">{stop.name}</h2>
+              <p className="mt-1 text-xs text-[#71717a]">{stop.address}</p>
+              <button
+                type="button"
+                className="mt-2 inline-flex h-7 items-center gap-1 rounded-full bg-[#f4f4f5] px-3 text-xs font-medium text-[#52525b]"
+              >
+                <MapPin className="size-3" aria-hidden />
+                장소 정보
+              </button>
+
+              <div className="mt-4 flex items-center gap-2 text-xs text-[#71717a]">
+                <PersonStanding className="size-4" aria-hidden />
+                <span>{stop.walkingTime}</span>
+              </div>
+            </article>
+          ))}
+        </div>
+      </div>
+
+      {primaryStop ? (
+        <div className="rounded-2xl border border-[#eeeeee] bg-[#fafafa] px-4 py-4">
+          <h2 className="text-sm font-bold text-[#171717]">{primaryStop.name}</h2>
+          <p className="mt-1 text-xs text-[#71717a]">{primaryStop.address}</p>
+
+          <button
+            type="button"
+            className="mt-3 inline-flex h-8 w-full items-center justify-center rounded-full border border-[#dedede] bg-white text-xs font-semibold text-[#52525b]"
+          >
+            내가 찾던 장소 다시보기
+          </button>
+
+          <div className="mt-4 flex items-center justify-between text-xs text-[#52525b]">
+            <span>{primaryStop.category}</span>
+            <span className="inline-flex items-center gap-1">
+              {primaryStop.hours}
+              <ChevronDown className="size-3" aria-hidden />
+            </span>
+          </div>
+        </div>
+      ) : null}
+    </section>
+  );
+}

--- a/src/components/course-planner/CoursePlannerActions.tsx
+++ b/src/components/course-planner/CoursePlannerActions.tsx
@@ -1,0 +1,36 @@
+﻿import { RotateCcw } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+
+type CoursePlannerActionsProps = {
+  canGenerate: boolean;
+  onGenerate: () => void;
+  onReset: () => void;
+};
+
+export function CoursePlannerActions({ canGenerate, onGenerate, onReset }: CoursePlannerActionsProps) {
+  return (
+    <div className="mt-5 flex gap-2">
+      <button
+        type="button"
+        onClick={onReset}
+        className="inline-flex size-11 items-center justify-center rounded-lg border border-[#d9d9d9] bg-white text-[#5f6368] transition-colors hover:bg-[#f8f8f8] focus-visible:outline-none focus-visible:ring-3 focus-visible:ring-ring/50 disabled:pointer-events-none disabled:opacity-50"
+        aria-label="다시 설정하기"
+      >
+        <RotateCcw className="size-4" aria-hidden />
+      </button>
+
+      <button
+        type="button"
+        onClick={onGenerate}
+        disabled={!canGenerate}
+        className={cn(
+          "inline-flex h-11 flex-1 items-center justify-center rounded-lg text-sm font-semibold text-white transition-colors focus-visible:outline-none focus-visible:ring-3 focus-visible:ring-ring/50 disabled:pointer-events-none",
+          canGenerate ? "bg-[#f06f6b] hover:bg-[#e86460]" : "bg-[#aaaaaa]",
+        )}
+      >
+        데이트코스 생성하기
+      </button>
+    </div>
+  );
+}

--- a/src/components/course-planner/CoursePlannerField.tsx
+++ b/src/components/course-planner/CoursePlannerField.tsx
@@ -1,0 +1,52 @@
+﻿import type { ReactNode } from "react";
+
+import { cn } from "@/lib/utils";
+
+type CoursePlannerFieldProps = {
+  label: string;
+  value: string;
+  placeholder?: string;
+  required?: boolean;
+  icon?: ReactNode;
+  className?: string;
+  onClick?: () => void;
+};
+
+export function CoursePlannerField({
+  label,
+  value,
+  placeholder,
+  required = false,
+  icon,
+  className,
+  onClick,
+}: CoursePlannerFieldProps) {
+  const hasValue = value.trim().length > 0;
+
+  return (
+    <div className={cn("grid gap-2", className)}>
+      <span className="text-sm font-semibold text-[#171717]">
+        {label}
+        {required ? <span className="ml-0.5 text-[#f06f6b]">*</span> : null}
+      </span>
+
+      <button
+        type="button"
+        onClick={onClick}
+        className="flex h-11 w-full items-center justify-between rounded-lg border border-[#dedede] bg-white px-3 text-left transition-colors hover:bg-[#fafafa] focus-visible:outline-none focus-visible:ring-3 focus-visible:ring-ring/50"
+      >
+        <span
+          className={cn(
+            "text-sm",
+            hasValue ? "font-medium text-[#171717]" : "text-[#9ca3af]",
+          )}
+        >
+          {hasValue ? value : placeholder}
+        </span>
+        <span className="text-[#6b7280]" aria-hidden>
+          {icon ?? "›"}
+        </span>
+      </button>
+    </div>
+  );
+}

--- a/src/components/course-planner/CoursePlannerMapPreview.tsx
+++ b/src/components/course-planner/CoursePlannerMapPreview.tsx
@@ -1,0 +1,91 @@
+﻿import { MapPin, Search } from "lucide-react";
+
+const categoryLabels = ["맛집", "카페", "놀거리", "기타"];
+
+type CoursePlannerMapPreviewProps = {
+  statusMessage?: string;
+  onMapClick?: () => void;
+};
+
+export function CoursePlannerMapPreview({ statusMessage, onMapClick }: CoursePlannerMapPreviewProps) {
+  return (
+    <section className="relative h-[320px] overflow-hidden bg-[#eef3f5]">
+      <button
+        type="button"
+        onClick={onMapClick}
+        className="absolute inset-0 cursor-default text-left"
+        aria-label="지도 영역"
+      >
+        <span className="absolute inset-0 bg-[#edf3f1]" />
+        <span className="absolute -left-16 top-8 h-28 w-80 rotate-[-18deg] rounded-full bg-[#dbeed6] blur-[1px]" />
+        <span className="absolute -right-10 bottom-8 h-32 w-72 rotate-[16deg] rounded-full bg-[#dbeaf7] blur-[1px]" />
+        <span className="absolute left-[-80px] top-44 h-8 w-[560px] rotate-[-18deg] rounded-full bg-white shadow-[inset_0_0_0_1px_rgba(209,213,219,0.8)]" />
+        <span className="absolute left-[-70px] top-48 h-2 w-[560px] rotate-[-18deg] rounded-full bg-[#f4d17f]/80" />
+        <span className="absolute left-[-40px] top-28 h-7 w-[520px] rotate-[28deg] rounded-full bg-white shadow-[inset_0_0_0_1px_rgba(209,213,219,0.8)]" />
+        <span className="absolute left-[-30px] top-31 h-1.5 w-[520px] rotate-[28deg] rounded-full bg-[#8cc3d8]/80" />
+        <span className="absolute left-10 top-20 h-4 w-[360px] rotate-[-6deg] rounded-full bg-white/90 shadow-[inset_0_0_0_1px_rgba(226,232,240,0.9)]" />
+        <span className="absolute left-28 top-24 text-[0.68rem] font-semibold text-[#8a8f98]">이문1동</span>
+        <span className="absolute right-20 top-28 text-[0.68rem] font-semibold text-[#8a8f98]">외대앞역</span>
+        <span className="absolute left-36 bottom-20 text-[0.68rem] font-semibold text-[#8a8f98]">회기동</span>
+        <span className="absolute left-[7.2rem] top-[8.7rem] h-0.5 w-[9.4rem] rotate-[-34deg] origin-left bg-[#ef746f] shadow-[0_0_0_2px_rgba(255,255,255,0.7)]" />
+        <span className="absolute left-[12.6rem] top-[5.45rem] h-0.5 w-[7rem] rotate-[48deg] origin-left bg-[#ef746f] shadow-[0_0_0_2px_rgba(255,255,255,0.7)]" />
+        <MapMarker className="left-[6.6rem] top-[8.1rem]" label="1" />
+        <MapMarker className="left-[12.1rem] top-[4.7rem]" label="2" />
+        <MapMarker className="left-[15.3rem] top-[9.9rem]" label="3" />
+        <span className="absolute bottom-14 right-5 flex size-9 items-center justify-center rounded-full bg-white/95 text-xs font-bold text-[#6b7280] shadow-md">
+          ◎
+        </span>
+      </button>
+
+      {statusMessage ? (
+        <div className="absolute left-4 right-4 top-6 z-20 rounded-sm bg-[#ef746f] px-4 py-2 text-center text-xs font-semibold text-white shadow-sm">
+          {statusMessage}
+        </div>
+      ) : null}
+
+      <div className="relative z-10 bg-[#f47f7b] px-4 pb-3 pt-8 text-white">
+        <div className="flex items-center gap-2 text-sm font-semibold">
+          <MapPin className="size-5 fill-white" aria-hidden />
+          <span>실한 두줄 지도</span>
+        </div>
+      </div>
+
+      <div className="relative z-10 px-4 pt-3">
+        <div className="flex h-10 items-center gap-3 rounded-full bg-white/95 px-4 shadow-[0_8px_22px_rgba(15,23,42,0.12)] backdrop-blur-sm">
+          <span className="flex-1 text-sm text-[#6b7280]">
+            저장해둔 장소를 검색해 보세요
+          </span>
+          <Search className="size-5 text-[#4b5563]" aria-hidden />
+        </div>
+
+        <div className="mt-3 flex gap-2 overflow-hidden">
+          {categoryLabels.map((label, index) => (
+            <span
+              key={label}
+              className="rounded-full bg-white/95 px-3 py-1.5 text-xs font-medium text-[#4b5563] shadow-sm backdrop-blur-sm"
+            >
+              {index === 0 ? "🍴 " : index === 1 ? "☕ " : index === 2 ? "🚩 " : "＋ "}
+              {label}
+            </span>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+type MapMarkerProps = {
+  className: string;
+  label: string;
+};
+
+function MapMarker({ className, label }: MapMarkerProps) {
+  return (
+    <span className={`absolute ${className} flex flex-col items-center`} aria-hidden>
+      <span className="flex size-6 items-center justify-center rounded-full border-2 border-white bg-[#ef746f] text-[0.65rem] font-bold text-white shadow-md">
+        {label}
+      </span>
+      <span className="-mt-1 size-2 rotate-45 bg-[#ef746f] shadow-sm" />
+    </span>
+  );
+}

--- a/src/components/course-planner/CoursePlannerPanel.tsx
+++ b/src/components/course-planner/CoursePlannerPanel.tsx
@@ -1,0 +1,79 @@
+﻿import { CalendarDays, Coffee, Flag, MoreHorizontal, Utensils } from "lucide-react";
+
+import { CoursePlannerActions } from "@/components/course-planner/CoursePlannerActions";
+import { CoursePlannerField } from "@/components/course-planner/CoursePlannerField";
+import { PlaceTypeChip } from "@/components/course-planner/PlaceTypeChip";
+
+export type PlaceTypeId = "restaurant" | "cafe" | "activity" | "etc";
+
+type CoursePlannerPanelProps = {
+  regionValue: string;
+  dateTimeValue: string;
+  selectedPlaceTypeIds: PlaceTypeId[];
+  canGenerate: boolean;
+  onOpenRegionSelect: () => void;
+  onOpenDateTimeSelect: () => void;
+  onTogglePlaceType: (placeTypeId: PlaceTypeId) => void;
+  onGenerate: () => void;
+  onReset: () => void;
+};
+
+const placeTypes: Array<{ id: PlaceTypeId; label: string; icon: React.ReactNode }> = [
+  { id: "restaurant", label: "맛집", icon: <Utensils className="size-3.5" /> },
+  { id: "cafe", label: "카페", icon: <Coffee className="size-3.5" /> },
+  { id: "activity", label: "놀거리", icon: <Flag className="size-3.5" /> },
+  { id: "etc", label: "기타", icon: <MoreHorizontal className="size-3.5" /> },
+];
+
+export function CoursePlannerPanel({
+  regionValue,
+  dateTimeValue,
+  selectedPlaceTypeIds,
+  canGenerate,
+  onOpenRegionSelect,
+  onOpenDateTimeSelect,
+  onTogglePlaceType,
+  onGenerate,
+  onReset,
+}: CoursePlannerPanelProps) {
+  return (
+    <section className="relative z-20 -mt-9 rounded-t-[28px] bg-white px-4 pb-7 pt-7 shadow-[0_-16px_40px_rgba(15,23,42,0.08)]">
+      <h1 className="text-lg font-bold text-[#171717]">맞춤 데이트코스 설정하기</h1>
+
+      <div className="mt-6 grid gap-5">
+        <CoursePlannerField
+          label="지역설정"
+          required
+          value={regionValue}
+          placeholder="지역을 선택해주세요."
+          onClick={onOpenRegionSelect}
+        />
+
+        <CoursePlannerField
+          label="날짜 및 시간 설정"
+          value={dateTimeValue}
+          placeholder="날짜 및 시간을 설정해주세요."
+          icon={<CalendarDays className="size-4" aria-hidden />}
+          onClick={onOpenDateTimeSelect}
+        />
+
+        <div className="grid gap-2">
+          <span className="text-sm font-semibold text-[#171717]">장소 종류</span>
+          <div className="flex flex-wrap gap-2">
+            {placeTypes.map((type) => (
+              <PlaceTypeChip
+                key={type.id}
+                label={type.label}
+                icon={type.icon}
+                selected={selectedPlaceTypeIds.includes(type.id)}
+                onClick={() => onTogglePlaceType(type.id)}
+              />
+            ))}
+          </div>
+        </div>
+      </div>
+
+      <CoursePlannerActions canGenerate={canGenerate} onGenerate={onGenerate} onReset={onReset} />
+    </section>
+  );
+}

--- a/src/components/course-planner/CourseResultPanel.tsx
+++ b/src/components/course-planner/CourseResultPanel.tsx
@@ -1,0 +1,53 @@
+﻿import { ChevronRight } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+
+export type CourseOption = {
+  id: string;
+  title: string;
+  description: string;
+};
+
+type CourseResultPanelProps = {
+  courses: CourseOption[];
+  selectedCourseId: string;
+  onSelectCourse: (courseId: string) => void;
+};
+
+export function CourseResultPanel({ courses, selectedCourseId, onSelectCourse }: CourseResultPanelProps) {
+  return (
+    <section className="relative z-20 -mt-9 rounded-t-[28px] bg-white px-4 pb-7 pt-7 shadow-[0_-16px_40px_rgba(15,23,42,0.08)]">
+      <div className="mx-auto mb-6 h-1 w-14 rounded-full bg-[#d9d9d9]" />
+
+      <h1 className="text-lg font-bold text-[#171717]">맞춤 데이트코스 확인하기</h1>
+      <p className="mt-2 text-sm leading-5 text-[#71717a]">
+        마음에 드는 코스를 선택해서 장소 정보를 확인해보세요.
+      </p>
+
+      <div className="mt-6 grid gap-3">
+        {courses.map((course) => {
+          const selected = course.id === selectedCourseId;
+          return (
+            <button
+              key={course.id}
+              type="button"
+              onClick={() => onSelectCourse(course.id)}
+              className={cn(
+                "flex h-12 items-center justify-between rounded-lg border px-4 text-left transition-colors focus-visible:outline-none focus-visible:ring-3 focus-visible:ring-ring/50",
+                selected
+                  ? "border-[#f06f6b] bg-[#fff0ee]"
+                  : "border-[#dedede] bg-white hover:bg-[#fafafa]",
+              )}
+            >
+              <span>
+                <span className="block text-sm font-semibold text-[#171717]">{course.title}</span>
+                <span className="mt-0.5 block text-xs text-[#71717a]">{course.description}</span>
+              </span>
+              <ChevronRight className="size-4 text-[#52525b]" aria-hidden />
+            </button>
+          );
+        })}
+      </div>
+    </section>
+  );
+}

--- a/src/components/course-planner/DateTimeSelectionPanel.tsx
+++ b/src/components/course-planner/DateTimeSelectionPanel.tsx
@@ -1,0 +1,192 @@
+﻿import { CalendarDays, ChevronLeft } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+
+export type DateTimeSelection = {
+  date: string;
+  weekday: string;
+  startTime: string | null;
+  endTime: string | null;
+};
+
+type DateTimeSelectionPanelProps = {
+  selectedDate: string;
+  selectedStartTime: string | null;
+  selectedEndTime: string | null;
+  onSelectDate: (date: string) => void;
+  onSelectStartTime: (time: string | null) => void;
+  onSelectEndTime: (time: string | null) => void;
+  onClose: () => void;
+  onConfirm: () => void;
+};
+
+const weekdays = ["일", "월", "화", "수", "목", "금", "토"];
+const monthLabel = "April 2026";
+const dateOptions = Array.from({ length: 14 }, (_, index) => {
+  const day = 14 + index;
+  const date = `2026.04.${String(day).padStart(2, "0")}`;
+  const weekday = weekdays[new Date(2026, 3, day).getDay()];
+  return { date, day, weekday };
+});
+const timeOptions = ["11:00", "12:00", "13:00", "14:00", "15:00", "16:00", "17:00", "18:00", "19:00", "20:00", "21:00"];
+
+export function getDateTimeDisplayValue(selection: DateTimeSelection | null) {
+  if (!selection) return "";
+  if (!selection.startTime || !selection.endTime) {
+    return `${selection.date} ${selection.weekday}요일`;
+  }
+  return `${selection.date} ${selection.weekday}요일 ${selection.startTime} ~ ${selection.endTime}`;
+}
+
+export function DateTimeSelectionPanel({
+  selectedDate,
+  selectedStartTime,
+  selectedEndTime,
+  onSelectDate,
+  onSelectStartTime,
+  onSelectEndTime,
+  onClose,
+  onConfirm,
+}: DateTimeSelectionPanelProps) {
+  const selectedDateOption = dateOptions.find((option) => option.date === selectedDate) ?? dateOptions[0];
+  const hasTimeRange = selectedStartTime != null && selectedEndTime != null;
+
+  return (
+    <section className="relative z-20 -mt-9 rounded-t-[28px] bg-white px-4 pb-7 pt-5 shadow-[0_-16px_40px_rgba(15,23,42,0.08)]">
+      <div className="mx-auto mb-4 h-1 w-14 rounded-full bg-[#d9d9d9]" />
+
+      <header className="flex items-center gap-2">
+        <button
+          type="button"
+          onClick={onClose}
+          className="inline-flex size-8 items-center justify-center rounded-full text-[#52525b] transition-colors hover:bg-[#f4f4f5] focus-visible:outline-none focus-visible:ring-3 focus-visible:ring-ring/50"
+          aria-label="날짜 및 시간 설정 닫기"
+        >
+          <ChevronLeft className="size-4" aria-hidden />
+        </button>
+        <h1 className="text-base font-bold text-[#171717]">날짜 및 시간 설정</h1>
+      </header>
+
+      <div className="mt-5 rounded-2xl border border-[#eeeeee] bg-white p-4 shadow-sm">
+        <div className="flex items-center justify-between">
+          <div>
+            <p className="text-sm font-bold text-[#171717]">{monthLabel}</p>
+            <p className="mt-1 text-xs text-[#9ca3af]">오늘 이후 날짜만 선택할 수 있어요</p>
+          </div>
+          <CalendarDays className="size-5 text-[#f06f6b]" aria-hidden />
+        </div>
+
+        <div className="mt-4 grid grid-cols-7 gap-1 text-center text-[0.7rem] font-semibold text-[#a1a1aa]">
+          {weekdays.map((weekday) => (
+            <span key={weekday}>{weekday}</span>
+          ))}
+        </div>
+
+        <div className="mt-2 grid grid-cols-7 gap-1">
+          {dateOptions.map((option) => {
+            const selected = option.date === selectedDateOption.date;
+            return (
+              <button
+                key={option.date}
+                type="button"
+                onClick={() => onSelectDate(option.date)}
+                className={cn(
+                  "flex aspect-square items-center justify-center rounded-full text-sm transition-colors focus-visible:outline-none focus-visible:ring-3 focus-visible:ring-ring/50",
+                  selected ? "bg-[#f06f6b] font-bold text-white" : "text-[#171717] hover:bg-[#fff0ee]",
+                )}
+                aria-label={`${option.date} ${option.weekday}요일`}
+              >
+                {option.day}
+              </button>
+            );
+          })}
+        </div>
+      </div>
+
+      <div className="mt-5 grid gap-3">
+        <div className="flex items-center justify-between">
+          <h2 className="text-sm font-bold text-[#171717]">시간 설정</h2>
+          <button
+            type="button"
+            onClick={() => {
+              onSelectStartTime(null);
+              onSelectEndTime(null);
+            }}
+            className={cn(
+              "rounded-full px-3 py-1 text-xs font-semibold transition-colors",
+              hasTimeRange ? "bg-[#f4f4f5] text-[#71717a]" : "bg-[#fff0ee] text-[#f06f6b]",
+            )}
+          >
+            시간 지정 안 함
+          </button>
+        </div>
+
+        <div className="grid grid-cols-2 gap-3">
+          <TimeColumn
+            label="시작"
+            selectedTime={selectedStartTime}
+            options={timeOptions.slice(0, -1)}
+            onSelect={(time) => {
+              onSelectStartTime(time);
+              if (!selectedEndTime || time >= selectedEndTime) {
+                onSelectEndTime("21:00");
+              }
+            }}
+          />
+          <TimeColumn
+            label="종료"
+            selectedTime={selectedEndTime}
+            options={timeOptions.slice(1)}
+            onSelect={(time) => {
+              if (selectedStartTime && time <= selectedStartTime) return;
+              onSelectEndTime(time);
+            }}
+          />
+        </div>
+      </div>
+
+      <button
+        type="button"
+        onClick={onConfirm}
+        className="mt-5 inline-flex h-11 w-full items-center justify-center rounded-lg bg-[#f06f6b] text-sm font-semibold text-white transition-colors hover:bg-[#e86460] focus-visible:outline-none focus-visible:ring-3 focus-visible:ring-ring/50"
+      >
+        {hasTimeRange
+          ? `${selectedDateOption.date} ${selectedStartTime} ~ ${selectedEndTime} 설정하기`
+          : `${selectedDateOption.date} 설정하기`}
+      </button>
+    </section>
+  );
+}
+
+type TimeColumnProps = {
+  label: string;
+  selectedTime: string | null;
+  options: string[];
+  onSelect: (time: string) => void;
+};
+
+function TimeColumn({ label, selectedTime, options, onSelect }: TimeColumnProps) {
+  return (
+    <div className="rounded-2xl border border-[#eeeeee] bg-[#fafafa] p-2">
+      <p className="px-2 py-1 text-xs font-semibold text-[#71717a]">{label}</p>
+      <div className="mt-1 grid max-h-44 gap-1 overflow-y-auto pr-1">
+        {options.map((time) => {
+          const selected = time === selectedTime;
+          return (
+            <button
+              key={time}
+              type="button"
+              onClick={() => onSelect(time)}
+              className={cn(
+                "h-9 rounded-lg text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-3 focus-visible:ring-ring/50",
+                selected ? "bg-[#fff0ee] text-[#f06f6b]" : "bg-white text-[#52525b] hover:bg-[#f4f4f5]",
+              )}
+            >
+              {time}
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/src/components/course-planner/DateTimeSelectionPanel.tsx
+++ b/src/components/course-planner/DateTimeSelectionPanel.tsx
@@ -1,4 +1,4 @@
-﻿import { CalendarDays, ChevronLeft } from "lucide-react";
+import { ChevronLeft, ChevronRight } from "lucide-react";
 
 import { cn } from "@/lib/utils";
 
@@ -20,22 +20,25 @@ type DateTimeSelectionPanelProps = {
   onConfirm: () => void;
 };
 
-const weekdays = ["일", "월", "화", "수", "목", "금", "토"];
+const weekdayLabels = ["SUN", "MON", "TUE", "WED", "THU", "FRI", "SAT"];
+const weekdaysKo = ["\uc77c", "\uc6d4", "\ud654", "\uc218", "\ubaa9", "\uae08", "\ud1a0"];
 const monthLabel = "April 2026";
-const dateOptions = Array.from({ length: 14 }, (_, index) => {
-  const day = 14 + index;
+const monthStartBlankCount = 3;
+const dateOptions = Array.from({ length: 30 }, (_, index) => {
+  const day = index + 1;
   const date = `2026.04.${String(day).padStart(2, "0")}`;
-  const weekday = weekdays[new Date(2026, 3, day).getDay()];
+  const weekday = weekdaysKo[new Date(2026, 3, day).getDay()];
   return { date, day, weekday };
 });
-const timeOptions = ["11:00", "12:00", "13:00", "14:00", "15:00", "16:00", "17:00", "18:00", "19:00", "20:00", "21:00"];
+const startTimeOptions = ["11:00", "12:00", "13:00", "14:00", "15:00"];
+const endTimeOptions = ["18:00", "19:00", "20:00", "21:00"];
 
 export function getDateTimeDisplayValue(selection: DateTimeSelection | null) {
   if (!selection) return "";
   if (!selection.startTime || !selection.endTime) {
-    return `${selection.date} ${selection.weekday}요일`;
+    return `${selection.date} ${selection.weekday}\uc694\uc77c`;
   }
-  return `${selection.date} ${selection.weekday}요일 ${selection.startTime} ~ ${selection.endTime}`;
+  return `${selection.date} ${selection.weekday}\uc694\uc77c ${selection.startTime} ~ ${selection.endTime}`;
 }
 
 export function DateTimeSelectionPanel({
@@ -48,128 +51,149 @@ export function DateTimeSelectionPanel({
   onClose,
   onConfirm,
 }: DateTimeSelectionPanelProps) {
-  const selectedDateOption = dateOptions.find((option) => option.date === selectedDate) ?? dateOptions[0];
+  const selectedDateOption = dateOptions.find((option) => option.date === selectedDate) ?? dateOptions[19];
   const hasTimeRange = selectedStartTime != null && selectedEndTime != null;
+  const confirmLabel = hasTimeRange
+    ? `${selectedDateOption.date} ${selectedStartTime} ~ ${selectedEndTime} \uc124\uc815\ud558\uae30`
+    : `${selectedDateOption.date} \uc124\uc815\ud558\uae30`;
 
   return (
-    <section className="relative z-20 -mt-9 rounded-t-[28px] bg-white px-4 pb-7 pt-5 shadow-[0_-16px_40px_rgba(15,23,42,0.08)]">
-      <div className="mx-auto mb-4 h-1 w-14 rounded-full bg-[#d9d9d9]" />
-
-      <header className="flex items-center gap-2">
-        <button
-          type="button"
-          onClick={onClose}
-          className="inline-flex size-8 items-center justify-center rounded-full text-[#52525b] transition-colors hover:bg-[#f4f4f5] focus-visible:outline-none focus-visible:ring-3 focus-visible:ring-ring/50"
-          aria-label="날짜 및 시간 설정 닫기"
-        >
-          <ChevronLeft className="size-4" aria-hidden />
-        </button>
-        <h1 className="text-base font-bold text-[#171717]">날짜 및 시간 설정</h1>
-      </header>
-
-      <div className="mt-5 rounded-2xl border border-[#eeeeee] bg-white p-4 shadow-sm">
-        <div className="flex items-center justify-between">
-          <div>
-            <p className="text-sm font-bold text-[#171717]">{monthLabel}</p>
-            <p className="mt-1 text-xs text-[#9ca3af]">오늘 이후 날짜만 선택할 수 있어요</p>
-          </div>
-          <CalendarDays className="size-5 text-[#f06f6b]" aria-hidden />
-        </div>
-
-        <div className="mt-4 grid grid-cols-7 gap-1 text-center text-[0.7rem] font-semibold text-[#a1a1aa]">
-          {weekdays.map((weekday) => (
-            <span key={weekday}>{weekday}</span>
-          ))}
-        </div>
-
-        <div className="mt-2 grid grid-cols-7 gap-1">
-          {dateOptions.map((option) => {
-            const selected = option.date === selectedDateOption.date;
-            return (
-              <button
-                key={option.date}
-                type="button"
-                onClick={() => onSelectDate(option.date)}
-                className={cn(
-                  "flex aspect-square items-center justify-center rounded-full text-sm transition-colors focus-visible:outline-none focus-visible:ring-3 focus-visible:ring-ring/50",
-                  selected ? "bg-[#f06f6b] font-bold text-white" : "text-[#171717] hover:bg-[#fff0ee]",
-                )}
-                aria-label={`${option.date} ${option.weekday}요일`}
-              >
-                {option.day}
-              </button>
-            );
-          })}
-        </div>
-      </div>
-
-      <div className="mt-5 grid gap-3">
-        <div className="flex items-center justify-between">
-          <h2 className="text-sm font-bold text-[#171717]">시간 설정</h2>
+    <section className="relative z-30 -mt-44 flex justify-center px-4 pb-7">
+      <div className="w-[280px] overflow-hidden rounded-xl bg-white shadow-[0_18px_50px_rgba(15,23,42,0.22)] ring-1 ring-black/5">
+        <header className="flex items-center justify-between px-3.5 py-3">
           <button
             type="button"
-            onClick={() => {
-              onSelectStartTime(null);
-              onSelectEndTime(null);
-            }}
-            className={cn(
-              "rounded-full px-3 py-1 text-xs font-semibold transition-colors",
-              hasTimeRange ? "bg-[#f4f4f5] text-[#71717a]" : "bg-[#fff0ee] text-[#f06f6b]",
-            )}
+            onClick={onClose}
+            className="inline-flex size-7 items-center justify-center rounded-full text-[#454545] transition-colors hover:bg-[#f4f4f5] focus-visible:outline-none focus-visible:ring-3 focus-visible:ring-ring/50"
+            aria-label="\ub0a0\uc9dc \ubc0f \uc2dc\uac04 \uc124\uc815 \ub2eb\uae30"
           >
-            시간 지정 안 함
+            <ChevronLeft className="size-4" aria-hidden />
+          </button>
+
+          <div className="flex items-center gap-1 text-sm font-bold text-[#252525]">
+            <span>{monthLabel}</span>
+            <ChevronRight className="size-3.5 text-[#2687d9]" aria-hidden />
+          </div>
+
+          <div className="flex items-center gap-1 text-[#2687d9]">
+            <button
+              type="button"
+              className="inline-flex size-7 items-center justify-center rounded-full transition-colors hover:bg-[#eef7ff] focus-visible:outline-none focus-visible:ring-3 focus-visible:ring-ring/50"
+              aria-label="\uc774\uc804 \ub2ec"
+            >
+              <ChevronLeft className="size-4" aria-hidden />
+            </button>
+            <button
+              type="button"
+              className="inline-flex size-7 items-center justify-center rounded-full transition-colors hover:bg-[#eef7ff] focus-visible:outline-none focus-visible:ring-3 focus-visible:ring-ring/50"
+              aria-label="\ub2e4\uc74c \ub2ec"
+            >
+              <ChevronRight className="size-4" aria-hidden />
+            </button>
+          </div>
+        </header>
+
+        <div className="px-3.5 pb-2">
+          <div className="grid grid-cols-7 text-center text-[0.58rem] font-semibold text-[#a3a3a3]">
+            {weekdayLabels.map((weekday) => (
+              <span key={weekday} className="py-1">
+                {weekday}
+              </span>
+            ))}
+          </div>
+
+          <div className="mt-1 grid grid-cols-7 gap-y-1 text-center">
+            {Array.from({ length: monthStartBlankCount }).map((_, index) => (
+              <span key={`blank-${index}`} aria-hidden />
+            ))}
+            {dateOptions.map((option) => {
+              const selected = option.date === selectedDateOption.date;
+              return (
+                <button
+                  key={option.date}
+                  type="button"
+                  onClick={() => onSelectDate(option.date)}
+                  className={cn(
+                    "mx-auto flex size-8 items-center justify-center rounded-full text-[0.8rem] font-medium transition-colors focus-visible:outline-none focus-visible:ring-3 focus-visible:ring-ring/50",
+                    selected ? "bg-[#7dd3fc] font-bold text-[#0f172a]" : "text-[#171717] hover:bg-[#f1f5f9]",
+                  )}
+                  aria-label={`${option.date} ${option.weekday}\uc694\uc77c`}
+                >
+                  {option.day}
+                </button>
+              );
+            })}
+          </div>
+        </div>
+
+        <div className="border-t border-[#ededed] px-3.5 py-2.5">
+          <div className="flex items-center justify-between gap-3">
+            <span className="text-xs font-semibold text-[#303030]">Time</span>
+            <button
+              type="button"
+              onClick={() => {
+                onSelectStartTime(null);
+                onSelectEndTime(null);
+              }}
+              className={cn(
+                "rounded-full px-2.5 py-1 text-[0.68rem] font-semibold transition-colors focus-visible:outline-none focus-visible:ring-3 focus-visible:ring-ring/50",
+                hasTimeRange ? "bg-[#f4f4f5] text-[#71717a] hover:bg-[#e9e9ec]" : "bg-[#fff0ee] text-[#f06f6b]",
+              )}
+            >
+              {hasTimeRange ? `${selectedStartTime} ~ ${selectedEndTime}` : "\uc2dc\uac04 \uc9c0\uc815 \uc548 \ud568"}
+            </button>
+          </div>
+
+          <div className="mt-2 grid gap-1.5">
+            <TimeChipRow
+              label="\uc2dc\uc791"
+              selectedTime={selectedStartTime}
+              options={startTimeOptions}
+              onSelect={(time) => {
+                onSelectStartTime(time);
+                if (!selectedEndTime || time >= selectedEndTime) {
+                  onSelectEndTime("21:00");
+                }
+              }}
+            />
+            <TimeChipRow
+              label="\uc885\ub8cc"
+              selectedTime={selectedEndTime}
+              options={endTimeOptions}
+              onSelect={(time) => {
+                if (selectedStartTime && time <= selectedStartTime) return;
+                onSelectEndTime(time);
+              }}
+            />
+          </div>
+        </div>
+
+        <div className="px-3.5 pb-3">
+          <button
+            type="button"
+            onClick={onConfirm}
+            className="inline-flex h-9 w-full items-center justify-center rounded-lg bg-[#f06f6b] text-xs font-semibold text-white transition-colors hover:bg-[#e86460] focus-visible:outline-none focus-visible:ring-3 focus-visible:ring-ring/50"
+          >
+            {confirmLabel}
           </button>
         </div>
-
-        <div className="grid grid-cols-2 gap-3">
-          <TimeColumn
-            label="시작"
-            selectedTime={selectedStartTime}
-            options={timeOptions.slice(0, -1)}
-            onSelect={(time) => {
-              onSelectStartTime(time);
-              if (!selectedEndTime || time >= selectedEndTime) {
-                onSelectEndTime("21:00");
-              }
-            }}
-          />
-          <TimeColumn
-            label="종료"
-            selectedTime={selectedEndTime}
-            options={timeOptions.slice(1)}
-            onSelect={(time) => {
-              if (selectedStartTime && time <= selectedStartTime) return;
-              onSelectEndTime(time);
-            }}
-          />
-        </div>
       </div>
-
-      <button
-        type="button"
-        onClick={onConfirm}
-        className="mt-5 inline-flex h-11 w-full items-center justify-center rounded-lg bg-[#f06f6b] text-sm font-semibold text-white transition-colors hover:bg-[#e86460] focus-visible:outline-none focus-visible:ring-3 focus-visible:ring-ring/50"
-      >
-        {hasTimeRange
-          ? `${selectedDateOption.date} ${selectedStartTime} ~ ${selectedEndTime} 설정하기`
-          : `${selectedDateOption.date} 설정하기`}
-      </button>
     </section>
   );
 }
 
-type TimeColumnProps = {
+type TimeChipRowProps = {
   label: string;
   selectedTime: string | null;
   options: string[];
   onSelect: (time: string) => void;
 };
 
-function TimeColumn({ label, selectedTime, options, onSelect }: TimeColumnProps) {
+function TimeChipRow({ label, selectedTime, options, onSelect }: TimeChipRowProps) {
   return (
-    <div className="rounded-2xl border border-[#eeeeee] bg-[#fafafa] p-2">
-      <p className="px-2 py-1 text-xs font-semibold text-[#71717a]">{label}</p>
-      <div className="mt-1 grid max-h-44 gap-1 overflow-y-auto pr-1">
+    <div className="flex items-center gap-1.5">
+      <span className="w-7 shrink-0 text-[0.65rem] font-semibold text-[#8a8a8a]">{label}</span>
+      <div className="flex min-w-0 flex-1 gap-1 overflow-x-auto pb-0.5">
         {options.map((time) => {
           const selected = time === selectedTime;
           return (
@@ -178,8 +202,8 @@ function TimeColumn({ label, selectedTime, options, onSelect }: TimeColumnProps)
               type="button"
               onClick={() => onSelect(time)}
               className={cn(
-                "h-9 rounded-lg text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-3 focus-visible:ring-ring/50",
-                selected ? "bg-[#fff0ee] text-[#f06f6b]" : "bg-white text-[#52525b] hover:bg-[#f4f4f5]",
+                "shrink-0 rounded-md px-2 py-1 text-[0.68rem] font-medium transition-colors focus-visible:outline-none focus-visible:ring-3 focus-visible:ring-ring/50",
+                selected ? "bg-[#fff0ee] text-[#f06f6b]" : "bg-[#fafafa] text-[#5f5f5f] hover:bg-[#f1f1f1]",
               )}
             >
               {time}

--- a/src/components/course-planner/PlaceTypeChip.tsx
+++ b/src/components/course-planner/PlaceTypeChip.tsx
@@ -1,0 +1,29 @@
+﻿import type { ReactNode } from "react";
+
+import { cn } from "@/lib/utils";
+
+type PlaceTypeChipProps = {
+  label: string;
+  icon: ReactNode;
+  selected?: boolean;
+  onClick?: () => void;
+};
+
+export function PlaceTypeChip({ label, icon, selected = false, onClick }: PlaceTypeChipProps) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      aria-pressed={selected}
+      className={cn(
+        "inline-flex h-8 items-center gap-1.5 rounded-lg border px-3 text-xs font-medium transition-colors focus-visible:outline-none focus-visible:ring-3 focus-visible:ring-ring/50",
+        selected
+          ? "border-[#f06f6b] bg-[#fff0ee] text-[#d95f5b]"
+          : "border-[#e5e7eb] bg-white text-[#4b5563] hover:bg-[#fafafa]",
+      )}
+    >
+      <span aria-hidden>{icon}</span>
+      {label}
+    </button>
+  );
+}

--- a/src/components/course-planner/RegionSelectionPanel.tsx
+++ b/src/components/course-planner/RegionSelectionPanel.tsx
@@ -1,0 +1,123 @@
+﻿import { Search, X } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+
+type RegionSelectionPanelProps = {
+  selectedCity: string;
+  selectedDistrict: string;
+  onSelectCity: (city: string) => void;
+  onSelectDistrict: (district: string) => void;
+  onClose: () => void;
+  onConfirm: () => void;
+};
+
+const cities = ["서울", "경기", "인천", "부산", "대구", "대전"];
+const districtsByCity: Record<string, string[]> = {
+  서울: ["전체", "강남구", "강동구", "강북구", "강서구", "관악구"],
+  경기: ["전체", "성남시", "수원시", "고양시", "용인시", "하남시"],
+  인천: ["전체", "남동구", "연수구", "부평구", "서구", "중구"],
+  부산: ["전체", "해운대구", "수영구", "부산진구", "동래구", "남구"],
+  대구: ["전체", "중구", "동구", "서구", "수성구", "달서구"],
+  대전: ["전체", "서구", "유성구", "중구", "동구", "대덕구"],
+};
+
+export function RegionSelectionPanel({
+  selectedCity,
+  selectedDistrict,
+  onSelectCity,
+  onSelectDistrict,
+  onClose,
+  onConfirm,
+}: RegionSelectionPanelProps) {
+  const districts = districtsByCity[selectedCity] ?? districtsByCity["서울"];
+  const confirmLabel = selectedDistrict === "전체"
+    ? `${selectedCity} 전체 설정하기`
+    : `${selectedCity} ${selectedDistrict} 설정하기`;
+
+  return (
+    <section className="relative z-20 -mt-9 rounded-t-[28px] bg-white px-4 pb-7 pt-5 shadow-[0_-16px_40px_rgba(15,23,42,0.08)]">
+      <div className="mx-auto mb-5 h-1 w-14 rounded-full bg-[#d9d9d9]" />
+
+      <div className="flex items-center justify-between">
+        <h1 className="text-base font-bold text-[#171717]">지역설정</h1>
+        <button
+          type="button"
+          onClick={onClose}
+          className="inline-flex size-8 items-center justify-center rounded-full text-[#9ca3af] transition-colors hover:bg-[#f4f4f5] focus-visible:outline-none focus-visible:ring-3 focus-visible:ring-ring/50"
+          aria-label="지역설정 닫기"
+        >
+          <X className="size-4" aria-hidden />
+        </button>
+      </div>
+
+      <label className="mt-4 flex h-11 items-center gap-2 rounded-lg border border-[#dedede] bg-white px-3">
+        <input
+          value={selectedDistrict === "전체" ? selectedCity : selectedDistrict}
+          readOnly
+          className="min-w-0 flex-1 bg-transparent text-sm font-medium text-[#171717] outline-none placeholder:text-[#9ca3af]"
+          placeholder="지역명 검색"
+          aria-label="지역명 검색"
+        />
+        <Search className="size-4 text-[#6b7280]" aria-hidden />
+      </label>
+
+      <div className="mt-4 grid grid-cols-2 overflow-hidden rounded-lg border border-[#eeeeee]">
+        <div className="border-r border-[#eeeeee]">
+          <div className="border-b border-[#eeeeee] py-2 text-center text-xs font-medium text-[#52525b]">
+            시/도
+          </div>
+          <div className="grid">
+            {cities.map((city) => {
+              const selected = city === selectedCity;
+              return (
+                <button
+                  key={city}
+                  type="button"
+                  onClick={() => onSelectCity(city)}
+                  className={cn(
+                    "h-11 px-4 text-left text-sm transition-colors",
+                    selected ? "bg-[#fff0ee] font-semibold text-[#f06f6b]" : "text-[#8a8f98] hover:bg-[#fafafa]",
+                  )}
+                >
+                  {city}
+                </button>
+              );
+            })}
+          </div>
+        </div>
+
+        <div>
+          <div className="border-b border-[#eeeeee] py-2 text-center text-xs font-medium text-[#52525b]">
+            시/구/군
+          </div>
+          <div className="grid">
+            {districts.map((district) => {
+              const selected = district === selectedDistrict;
+              return (
+                <button
+                  key={district}
+                  type="button"
+                  onClick={() => onSelectDistrict(district)}
+                  className={cn(
+                    "h-11 px-4 text-left text-sm transition-colors",
+                    selected ? "bg-[#ffe6e4] font-semibold text-[#f06f6b]" : "text-[#8a8f98] hover:bg-[#fafafa]",
+                  )}
+                >
+                  {district}
+                </button>
+              );
+            })}
+          </div>
+        </div>
+      </div>
+
+      <button
+        type="button"
+        onClick={onConfirm}
+        className="mt-5 inline-flex h-11 w-full items-center justify-center rounded-lg bg-[#f06f6b] text-sm font-semibold text-white transition-colors hover:bg-[#e86460] focus-visible:outline-none focus-visible:ring-3 focus-visible:ring-ring/50"
+      >
+        {confirmLabel}
+      </button>
+    </section>
+  );
+}

--- a/src/pages/tabs/CoursePlannerPage.tsx
+++ b/src/pages/tabs/CoursePlannerPage.tsx
@@ -1,23 +1,256 @@
+﻿import { useEffect, useState } from "react";
 import { Navigate } from "react-router-dom";
 
 import { BottomNavigationBar } from "@/components/common/BottomNavigationBar";
 import { BottomNavToast } from "@/components/common/BottomNavToast";
+import { CourseEditPanel } from "@/components/course-planner/CourseEditPanel";
+import { CourseGenerationLoadingPanel } from "@/components/course-planner/CourseGenerationLoadingPanel";
+import { CoursePlaceInfoPanel, type CourseStop } from "@/components/course-planner/CoursePlaceInfoPanel";
+import { CoursePlannerMapPreview } from "@/components/course-planner/CoursePlannerMapPreview";
+import { CoursePlannerPanel, type PlaceTypeId } from "@/components/course-planner/CoursePlannerPanel";
+import { CourseResultPanel, type CourseOption } from "@/components/course-planner/CourseResultPanel";
+import {
+  DateTimeSelectionPanel,
+  getDateTimeDisplayValue,
+  type DateTimeSelection,
+} from "@/components/course-planner/DateTimeSelectionPanel";
+import { RegionSelectionPanel } from "@/components/course-planner/RegionSelectionPanel";
 import { useBottomNavController } from "@/hooks/use-bottom-nav-controller";
 import { useRoomSelectionStore } from "@/store/room-selection-store";
 
-export function CoursePlannerPage() {
+type CoursePlannerMode = "form" | "region" | "datetime" | "loading" | "result" | "detail" | "edit";
+
+const mockCourses: CourseOption[] = [
+  { id: "course-1", title: "코스 1", description: "캠퍼스 산책부터 감동까지" },
+  { id: "course-2", title: "코스 2", description: "카페와 전시를 가볍게" },
+  { id: "course-3", title: "코스 3", description: "저녁까지 이어지는 여유 코스" },
+];
+
+const mockStops: CourseStop[] = [
+  {
+    id: "hufs-seoul",
+    name: "한국외국어대학교 서울캠퍼스",
+    address: "서울 동대문구 이문로 107",
+    category: "대학 · 캠퍼스",
+    walkingTime: "도보 10분",
+    hours: "10:40 ~ 19:30",
+  },
+  {
+    id: "gangneung",
+    name: "감동",
+    address: "회기로 25길 10-13 1층",
+    category: "맛집",
+    walkingTime: "도보 8분",
+    hours: "11:30 ~ 21:00",
+  },
+  {
+    id: "oegwan-street",
+    name: "사르스트 외대점",
+    address: "회기로 23길 2",
+    category: "카페",
+    walkingTime: "도보 7분",
+    hours: "12:00 ~ 22:00",
+  },
+];
+
+type CoursePlannerPageProps = {
+  skipRoomGuard?: boolean;
+};
+
+export function CoursePlannerPage({ skipRoomGuard = false }: CoursePlannerPageProps) {
   const selectedRoom = useRoomSelectionStore((s) => s.selectedRoom);
   const { toastMessage, handleSelectBottomNav } = useBottomNavController();
+  const [mode, setMode] = useState<CoursePlannerMode>("form");
+  const [regionValue, setRegionValue] = useState("");
+  const [draftCity, setDraftCity] = useState("서울");
+  const [draftDistrict, setDraftDistrict] = useState("강남구");
+  const [dateTimeValue, setDateTimeValue] = useState<DateTimeSelection | null>(null);
+  const [draftDate, setDraftDate] = useState("2026.04.20");
+  const [draftStartTime, setDraftStartTime] = useState<string | null>("13:00");
+  const [draftEndTime, setDraftEndTime] = useState<string | null>("21:00");
+  const [selectedPlaceTypeIds, setSelectedPlaceTypeIds] = useState<PlaceTypeId[]>(["restaurant"]);
+  const [selectedCourseId, setSelectedCourseId] = useState(mockCourses[0]?.id ?? "");
+  const [courseTitle, setCourseTitle] = useState(mockCourses[0]?.title ?? "코스 1");
+  const [courseStops, setCourseStops] = useState<CourseStop[]>(mockStops);
+  const [completionNoticeVisible, setCompletionNoticeVisible] = useState(false);
 
-  if (!selectedRoom) {
+  useEffect(() => {
+    if (mode !== "loading") return;
+
+    const timerId = window.setTimeout(() => {
+      setCompletionNoticeVisible(true);
+      setMode("result");
+    }, 900);
+
+    return () => window.clearTimeout(timerId);
+  }, [mode]);
+
+  useEffect(() => {
+    if (!completionNoticeVisible) return;
+
+    const timerId = window.setTimeout(() => {
+      setCompletionNoticeVisible(false);
+    }, 5000);
+
+    return () => window.clearTimeout(timerId);
+  }, [completionNoticeVisible]);
+
+  if (!skipRoomGuard && !selectedRoom) {
     return <Navigate to="/room" replace />;
   }
 
+  const canGenerate = regionValue.trim().length > 0 && selectedPlaceTypeIds.length > 0;
+
+  const handleSelectCity = (city: string) => {
+    setDraftCity(city);
+    setDraftDistrict("전체");
+  };
+
+  const handleConfirmRegion = () => {
+    setRegionValue(draftDistrict === "전체" ? draftCity : `${draftCity} ${draftDistrict}`);
+    setMode("form");
+  };
+
+  const handleConfirmDateTime = () => {
+    const weekday = new Date(draftDate.replaceAll(".", "/"))
+      .toLocaleDateString("ko-KR", { weekday: "short" })
+      .replace("요일", "");
+
+    setDateTimeValue({
+      date: draftDate,
+      weekday,
+      startTime: draftStartTime,
+      endTime: draftEndTime,
+    });
+    setMode("form");
+  };
+
+  const handleTogglePlaceType = (placeTypeId: PlaceTypeId) => {
+    setSelectedPlaceTypeIds((current) => {
+      if (current.includes(placeTypeId)) {
+        return current.filter((id) => id !== placeTypeId);
+      }
+      return [...current, placeTypeId];
+    });
+  };
+
+  const handleResetPlanner = () => {
+    setRegionValue("");
+    setDraftCity("서울");
+    setDraftDistrict("강남구");
+    setDateTimeValue(null);
+    setDraftDate("2026.04.20");
+    setDraftStartTime("13:00");
+    setDraftEndTime("21:00");
+    setSelectedPlaceTypeIds(["restaurant"]);
+    setCompletionNoticeVisible(false);
+    setMode("form");
+  };
+
+  const handleGenerateCourse = () => {
+    if (!canGenerate) return;
+    setMode("loading");
+  };
+
+  const handleSelectCourse = (courseId: string) => {
+    const selectedCourse = mockCourses.find((course) => course.id === courseId);
+    setSelectedCourseId(courseId);
+    setCourseTitle(selectedCourse?.title ?? "코스 1");
+    setCourseStops(mockStops);
+    setMode("detail");
+  };
+
+  const handleSaveCourseEdit = (nextTitle: string, nextStops: CourseStop[]) => {
+    setCourseTitle(nextTitle);
+    setCourseStops(nextStops);
+    setCompletionNoticeVisible(true);
+    setMode("detail");
+  };
+
+  const handleMapClick = () => {
+    if (mode === "detail" || mode === "edit") {
+      setMode("detail");
+    }
+  };
+
+  const statusMessage = completionNoticeVisible ? "데이트코스가 완성되었습니다" : undefined;
+
   return (
     <div className="-m-page relative flex min-h-0 flex-1 flex-col overflow-hidden">
-      <main className="bg-background min-h-0 flex-1" />
+      <main className="bg-background min-h-0 flex-1 overflow-y-auto pb-24">
+        <CoursePlannerMapPreview statusMessage={statusMessage} onMapClick={handleMapClick} />
+
+        {mode === "region" ? (
+          <RegionSelectionPanel
+            selectedCity={draftCity}
+            selectedDistrict={draftDistrict}
+            onSelectCity={handleSelectCity}
+            onSelectDistrict={setDraftDistrict}
+            onClose={() => setMode("form")}
+            onConfirm={handleConfirmRegion}
+          />
+        ) : null}
+
+        {mode === "datetime" ? (
+          <DateTimeSelectionPanel
+            selectedDate={draftDate}
+            selectedStartTime={draftStartTime}
+            selectedEndTime={draftEndTime}
+            onSelectDate={setDraftDate}
+            onSelectStartTime={setDraftStartTime}
+            onSelectEndTime={setDraftEndTime}
+            onClose={() => setMode("form")}
+            onConfirm={handleConfirmDateTime}
+          />
+        ) : null}
+
+        {mode === "form" ? (
+          <CoursePlannerPanel
+            regionValue={regionValue}
+            dateTimeValue={getDateTimeDisplayValue(dateTimeValue)}
+            selectedPlaceTypeIds={selectedPlaceTypeIds}
+            canGenerate={canGenerate}
+            onOpenRegionSelect={() => setMode("region")}
+            onOpenDateTimeSelect={() => setMode("datetime")}
+            onTogglePlaceType={handleTogglePlaceType}
+            onGenerate={handleGenerateCourse}
+            onReset={handleResetPlanner}
+          />
+        ) : null}
+
+        {mode === "loading" ? <CourseGenerationLoadingPanel /> : null}
+
+        {mode === "result" ? (
+          <CourseResultPanel
+            courses={mockCourses}
+            selectedCourseId={selectedCourseId}
+            onSelectCourse={handleSelectCourse}
+          />
+        ) : null}
+
+        {mode === "detail" ? (
+          <CoursePlaceInfoPanel
+            courseTitle={courseTitle}
+            stops={courseStops}
+            onBack={() => setMode("result")}
+            onEdit={() => setMode("edit")}
+          />
+        ) : null}
+
+        {mode === "edit" ? (
+          <CourseEditPanel
+            title={courseTitle}
+            stops={courseStops}
+            onBack={() => setMode("detail")}
+            onSave={handleSaveCourseEdit}
+          />
+        ) : null}
+      </main>
+
       <BottomNavToast message={toastMessage} />
       <BottomNavigationBar activeId="course" onSelect={handleSelectBottomNav} />
     </div>
   );
 }
+
+


### PR DESCRIPTION
## ✨ 무엇을 바꿨나요?

데이트 코스짜기 플로우의 프론트 UI를 구현했습니다.  
지역 설정, 날짜 및 시간 설정, 장소 종류 선택부터 코스 생성 결과/상세/편집 흐름까지 mock 데이터 기반으로 확인할 수 있도록 구성했습니다.

## 🔗 관련 이슈

Closes #5

## 💡 왜 바꿨나요?

백엔드 연동 전에도 데이트 코스 생성 흐름과 화면 전환 구조를 먼저 검증할 수 있도록 하기 위해 구현했습니다.

## 📝 주요 변경 사항

- 데이트 코스 설정 화면 UI 구현
- 지역 설정 패널 UI 구현
- 날짜 및 시간 선택 UI 구현
- 장소 종류 선택 UI 구현
- 코스 생성 로딩 UI 구현
- 코스 결과 리스트 및 선택 UI 구현
- 코스 상세 UI 구현
- 코스 편집, 순서 변경, 삭제 확인 UI 구현
- `/dev/course` 임시 확인 경로 추가

## 👀 리뷰어가 보면 좋은 부분


## 🧪 테스트

**방식** (해당하는 것만 체크)

- [o] 로컬 환경에서 확인
- [ ] 운영 환경에서 확인
- [ ] 단위 / 통합 테스트
- [ ] 해당 없음

**메모** (시나리오, 커맨드, 스크린샷 링크 등 — 선택)

- `npm run dev`
- `http://localhost:5173/dev/course` 에서 주요 플로우 확인
- API 연결 없이 mock 데이터 기반으로 UI 확인