### PR TITLE
Feat/6 mypage

### DIFF
--- a/src/app/router/index.tsx
+++ b/src/app/router/index.tsx
@@ -22,6 +22,7 @@ export const router = createBrowserRouter([
     children: [
       { index: true, element: <EntryPage /> },
       { path: "dev/splash", element: <SplashScreenPage /> },
+      { path: "dev/mypage", element: <MyPage /> },
       { path: "login", element: <LoginPage /> },
       { path: "app", element: <Navigate to="/" replace /> },
       {
@@ -61,3 +62,5 @@ export const router = createBrowserRouter([
     ],
   },
 ]);
+
+

--- a/src/components/mypage/MyAccountActions.tsx
+++ b/src/components/mypage/MyAccountActions.tsx
@@ -1,0 +1,25 @@
+﻿type MyAccountActionsProps = {
+  onLogout?: () => void;
+  onWithdraw?: () => void;
+};
+
+export function MyAccountActions({ onLogout, onWithdraw }: MyAccountActionsProps) {
+  return (
+    <div className="mt-6 flex justify-center gap-2 pb-8">
+      <button
+        type="button"
+        onClick={onLogout}
+        className="h-8 rounded-md border border-[#e5e5e5] bg-white px-4 text-xs font-medium text-[#444444] active:bg-[#f7f7f7]"
+      >
+        로그아웃
+      </button>
+      <button
+        type="button"
+        onClick={onWithdraw}
+        className="h-8 rounded-md border border-[#e5e5e5] bg-white px-4 text-xs font-medium text-[#444444] active:bg-[#f7f7f7]"
+      >
+        회원탈퇴
+      </button>
+    </div>
+  );
+}

--- a/src/components/mypage/MyPageCourseDetail.tsx
+++ b/src/components/mypage/MyPageCourseDetail.tsx
@@ -1,0 +1,59 @@
+﻿import { ArrowLeft, Footprints, MapPin, Pencil } from "lucide-react";
+
+import type { SavedCourse } from "./mypage-mock-data";
+
+type MyPageCourseDetailProps = {
+  course: SavedCourse;
+  onBack: () => void;
+};
+
+export function MyPageCourseDetail({ course, onBack }: MyPageCourseDetailProps) {
+  return (
+    <main className="bg-background min-h-0 flex-1 overflow-y-auto pb-28">
+      <section className="relative h-[17rem] overflow-hidden bg-[#eef3f5]">
+        <div className="absolute inset-0 bg-[linear-gradient(135deg,#eef1ec_0_25%,#ffffff_25%_50%,#e8f0f4_50%_75%,#ffffff_75%)] bg-[length:82px_82px]" />
+        <div className="absolute left-[-3rem] top-32 h-3 w-[30rem] rotate-[-9deg] rounded-full bg-[#2454b7]/75" />
+        <div className="absolute left-10 top-16 h-[2px] w-52 rotate-[30deg] bg-[#ef7773]" />
+        <div className="absolute left-20 top-24 h-[2px] w-40 rotate-[-28deg] bg-[#ef7773]" />
+        {["left-20 top-24", "left-36 top-16", "left-48 top-32"].map((position, index) => (
+          <span key={position} className={`absolute ${position} flex size-6 items-center justify-center rounded-full border border-[#ef7773] bg-white text-[0.65rem] font-bold text-[#ef7773]`}>
+            {index + 1}
+          </span>
+        ))}
+      </section>
+
+      <section className="relative -mt-10 rounded-t-[1.75rem] bg-white px-5 pb-8 pt-4 shadow-[0_-12px_24px_rgb(0_0_0_/_0.05)]">
+        <div className="mx-auto mb-5 h-1 w-14 rounded-full bg-[#d4d4d4]" />
+
+        <div className="flex items-center gap-2">
+          <button type="button" onClick={onBack} className="touch-target-min -ml-2 flex items-center justify-center rounded-full">
+            <ArrowLeft className="size-5 text-[#222222]" aria-hidden />
+            <span className="sr-only">마이페이지로 돌아가기</span>
+          </button>
+          <h1 className="min-w-0 flex-1 truncate text-lg font-bold text-[#111111]">{course.title}</h1>
+          <Pencil className="size-4 text-[#9a9a9a]" aria-hidden />
+        </div>
+
+        <ol className="mt-6 space-y-5 border-l border-dashed border-[#8f8f8f] pl-5">
+          {course.stops.map((stop) => (
+            <li key={stop.id} className="relative pl-1">
+              <span className="absolute -left-[1.82rem] top-0 size-3 rounded-full border-2 border-[#8f8f8f] bg-white" />
+              <h2 className="text-sm font-semibold text-[#222222]">{stop.name}</h2>
+              <p className="mt-1 text-[0.68rem] font-medium text-[#777777]">{stop.address}</p>
+              <button type="button" className="mt-2 inline-flex items-center gap-1 rounded-full bg-[#f6f6f6] px-2 py-1 text-[0.65rem] font-semibold text-[#222222]">
+                <MapPin className="size-3" aria-hidden />
+                장소 정보
+              </button>
+              {stop.walkingTime ? (
+                <p className="mt-3 flex items-center gap-1 text-[0.68rem] font-medium text-[#777777]">
+                  <Footprints className="size-3" aria-hidden />
+                  {stop.walkingTime}
+                </p>
+              ) : null}
+            </li>
+          ))}
+        </ol>
+      </section>
+    </main>
+  );
+}

--- a/src/components/mypage/MyPlaceSummaryCard.tsx
+++ b/src/components/mypage/MyPlaceSummaryCard.tsx
@@ -1,0 +1,55 @@
+﻿import { ChevronRight } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+
+import type { RecentPlace } from "./mypage-mock-data";
+
+type MyPlaceSummaryCardProps = {
+  totalCount: number;
+  recentPlaces: RecentPlace[];
+  onOpenPlaces?: () => void;
+  className?: string;
+};
+
+function formatCount(count: number) {
+  return count > 999 ? "999+" : String(count);
+}
+
+export function MyPlaceSummaryCard({
+  totalCount,
+  recentPlaces,
+  onOpenPlaces,
+  className,
+}: MyPlaceSummaryCardProps) {
+  const hasPlaces = totalCount > 0;
+
+  return (
+    <section className={cn("rounded-xl border border-[#e5e5e5] bg-white px-4 py-4", className)}>
+      <button
+        type="button"
+        onClick={onOpenPlaces}
+        className="touch-target-min flex w-full items-center justify-between text-left"
+      >
+        <h2 className="text-[0.95rem] font-semibold text-[#111111]">나의 장소</h2>
+        <ChevronRight className="size-4 text-[#222222]" aria-hidden />
+      </button>
+
+      <p className="mt-2 text-center text-2xl font-semibold text-[#111111]">{formatCount(totalCount)}개</p>
+
+      <div className="mt-5">
+        <p className="text-xs font-medium text-[#222222]">최근 저장 장소</p>
+        <div className="mt-2 divide-y divide-[#eeeeee]">
+          {hasPlaces ? (
+            recentPlaces.slice(0, 2).map((place) => (
+              <p key={place.id} className="truncate py-2 text-xs font-medium text-[#222222]">
+                {place.name}
+              </p>
+            ))
+          ) : (
+            <p className="truncate py-2 text-xs font-medium text-[#9a9a9a]">나의 장소를 저장해보세요!</p>
+          )}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/components/mypage/MyProfileHeader.tsx
+++ b/src/components/mypage/MyProfileHeader.tsx
@@ -1,0 +1,16 @@
+﻿import { UserRound } from "lucide-react";
+
+type MyProfileHeaderProps = {
+  nickname: string;
+};
+
+export function MyProfileHeader({ nickname }: MyProfileHeaderProps) {
+  return (
+    <header className="border-border/60 flex items-center gap-3 border-b bg-white px-5 py-5">
+      <span className="flex size-11 shrink-0 items-center justify-center rounded-full bg-[#d9d9d9] text-white">
+        <UserRound className="size-6" aria-hidden />
+      </span>
+      <p className="text-[1rem] font-semibold text-[#111111]">{nickname}님</p>
+    </header>
+  );
+}

--- a/src/components/mypage/MySavedPlacesPage.tsx
+++ b/src/components/mypage/MySavedPlacesPage.tsx
@@ -1,0 +1,116 @@
+﻿import { AlertCircle, ArrowLeft } from "lucide-react";
+import { useMemo, useState } from "react";
+
+import type { SavedPlace } from "./mypage-mock-data";
+import { SavedPlaceCategoryTabs, type SavedPlaceFilter } from "./SavedPlaceCategoryTabs";
+import { SavedPlaceItem } from "./SavedPlaceItem";
+
+type MySavedPlacesPageProps = {
+  places: SavedPlace[];
+  onBack: () => void;
+  onChangePlaces: (places: SavedPlace[]) => void;
+  onSelectPlace: (place: SavedPlace) => void;
+};
+
+function formatCount(count: number) {
+  return count > 999 ? "999+" : String(count);
+}
+
+export function MySavedPlacesPage({ places, onBack, onChangePlaces, onSelectPlace }: MySavedPlacesPageProps) {
+  const [selectedFilter, setSelectedFilter] = useState<SavedPlaceFilter>("all");
+  const [openMenuId, setOpenMenuId] = useState<string | null>(null);
+  const [editingPlaceId, setEditingPlaceId] = useState<string | null>(null);
+  const [memoDraft, setMemoDraft] = useState("");
+
+  const filteredPlaces = useMemo(() => {
+    if (selectedFilter === "all") {
+      return places;
+    }
+
+    return places.filter((place) => place.category === selectedFilter);
+  }, [places, selectedFilter]);
+
+  const emptyMessage = places.length === 0 ? "나의 장소를 저장해보세요!" : "해당하는 장소가 없습니다.";
+
+  const handleStartMemo = (place: SavedPlace) => {
+    setOpenMenuId(null);
+    setEditingPlaceId(place.id);
+    setMemoDraft(place.memo ?? "");
+  };
+
+  const handleSaveMemo = () => {
+    if (!editingPlaceId) {
+      return;
+    }
+
+    const nextMemo = memoDraft.trim();
+    onChangePlaces(
+      places.map((place) =>
+        place.id === editingPlaceId
+          ? {
+              ...place,
+              memo: nextMemo || undefined,
+            }
+          : place,
+      ),
+    );
+    setEditingPlaceId(null);
+    setMemoDraft("");
+  };
+
+  const handleDeletePlace = (id: string) => {
+    onChangePlaces(places.filter((place) => place.id !== id));
+    setOpenMenuId(null);
+    if (editingPlaceId === id) {
+      setEditingPlaceId(null);
+      setMemoDraft("");
+    }
+  };
+
+  return (
+    <main className="bg-background min-h-0 flex-1 overflow-y-auto pb-28">
+      <header className="sticky top-0 z-20 bg-white pt-[max(1rem,env(safe-area-inset-top))] shadow-[0_1px_0_rgb(0_0_0_/_0.06)]">
+        <div className="flex h-12 items-center px-5">
+          <button type="button" onClick={onBack} className="touch-target-min -ml-3 flex items-center justify-center rounded-full">
+            <ArrowLeft className="size-5 text-[#222222]" aria-hidden />
+            <span className="sr-only">마이페이지로 돌아가기</span>
+          </button>
+          <h1 className="flex-1 text-center text-base font-bold text-[#111111]">나의 장소</h1>
+          <span className="w-14 text-right text-xs font-semibold text-[#555555]">총 {formatCount(places.length)}개</span>
+        </div>
+
+        <SavedPlaceCategoryTabs selected={selectedFilter} onSelect={setSelectedFilter} />
+      </header>
+
+      <section className="px-5 pt-4">
+        {filteredPlaces.length > 0 ? (
+          <div className="space-y-2">
+            {filteredPlaces.map((place) => (
+              <SavedPlaceItem
+                key={place.id}
+                place={place}
+                isMenuOpen={openMenuId === place.id}
+                isEditing={editingPlaceId === place.id}
+                memoDraft={memoDraft}
+                onToggleMenu={(id) => setOpenMenuId((current) => (current === id ? null : id))}
+                onStartMemo={handleStartMemo}
+                onChangeMemo={setMemoDraft}
+                onSaveMemo={handleSaveMemo}
+                onClearMemo={() => setMemoDraft("")}
+                onDelete={handleDeletePlace}
+                onSelect={onSelectPlace}
+              />
+            ))}
+          </div>
+        ) : (
+          <div className="flex min-h-[26rem] flex-col items-center justify-center text-center">
+            <span className="flex size-11 items-center justify-center rounded-full bg-[#777777] text-white">
+              <AlertCircle className="size-5" aria-hidden />
+            </span>
+            <p className="mt-4 text-sm font-medium text-[#8a8a8a]">{emptyMessage}</p>
+          </div>
+        )}
+      </section>
+    </main>
+  );
+}

--- a/src/components/mypage/SavedCourseCard.tsx
+++ b/src/components/mypage/SavedCourseCard.tsx
@@ -1,0 +1,39 @@
+﻿import { ChevronRight, Heart, UsersRound } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+
+import type { SavedCourse } from "./mypage-mock-data";
+
+type SavedCourseCardProps = {
+  course: SavedCourse;
+  onSelect?: (course: SavedCourse) => void;
+  className?: string;
+};
+
+export function SavedCourseCard({ course, onSelect, className }: SavedCourseCardProps) {
+  const isFriendCourse = course.badgeLabel === "친구";
+  const Icon = isFriendCourse ? UsersRound : Heart;
+
+  return (
+    <button
+      type="button"
+      onClick={() => onSelect?.(course)}
+      className={cn(
+        "flex w-full items-center gap-3 rounded-xl border border-[#e8e8e8] bg-white px-3 py-3 text-left",
+        "transition-colors active:bg-[#fff2f1]",
+        className,
+      )}
+    >
+      <span className="flex size-10 shrink-0 items-center justify-center rounded-full bg-[#ffe1df] text-[#ef7773]">
+        {isFriendCourse ? <span className="text-[0.65rem] font-semibold">친구</span> : <Icon className="size-4 fill-current" aria-hidden />}
+      </span>
+
+      <span className="min-w-0 flex-1">
+        <span className="block truncate text-[0.82rem] font-semibold text-[#222222]">{course.title}</span>
+        <span className="mt-1 block truncate text-[0.68rem] font-medium text-[#777777]">{course.executedAtLabel}</span>
+      </span>
+
+      <ChevronRight className="size-4 shrink-0 text-[#222222]" aria-hidden />
+    </button>
+  );
+}

--- a/src/components/mypage/SavedCourseListPage.tsx
+++ b/src/components/mypage/SavedCourseListPage.tsx
@@ -1,0 +1,200 @@
+﻿import { AlertCircle, ArrowLeft, ChevronDown, ChevronLeft, ChevronRight } from "lucide-react";
+import { useMemo, useState } from "react";
+
+import { cn } from "@/lib/utils";
+
+import type { SavedCourse } from "./mypage-mock-data";
+import { SavedCourseCard } from "./SavedCourseCard";
+
+type SavedCourseListPageProps = {
+  courses: SavedCourse[];
+  onBack: () => void;
+  onSelectCourse: (course: SavedCourse) => void;
+};
+
+type CourseFilter = "all" | "room" | "date";
+type FilterPopup = Exclude<CourseFilter, "all"> | null;
+
+const rooms = ["친구와의 방", "연인의 방", "남친구와의 방", "친구 4, 친구 5, 친구 6..."];
+const aprilDates = Array.from({ length: 30 }, (_, index) => index + 1);
+
+function formatCount(count: number) {
+  return count > 999 ? "999+" : String(count);
+}
+
+function formatDateLabel(date: number | null) {
+  return date ? `2025.04.${String(date).padStart(2, "0")}` : "날짜";
+}
+
+export function SavedCourseListPage({ courses, onBack, onSelectCourse }: SavedCourseListPageProps) {
+  const [selectedFilter, setSelectedFilter] = useState<CourseFilter>("all");
+  const [openPopup, setOpenPopup] = useState<FilterPopup>(null);
+  const [selectedRooms, setSelectedRooms] = useState<string[]>([rooms[1]]);
+  const [selectedDate, setSelectedDate] = useState<number | null>(null);
+
+  const visibleCourses = useMemo(() => {
+    if (selectedFilter === "date" && selectedDate === 26) {
+      return [];
+    }
+
+    if (selectedFilter === "date" && selectedDate) {
+      return courses.slice(0, 4);
+    }
+
+    if (selectedFilter === "room" && selectedRooms.length === 0) {
+      return [];
+    }
+
+    if (selectedFilter === "room") {
+      return courses.slice(0, 4);
+    }
+
+    return courses;
+  }, [courses, selectedDate, selectedFilter, selectedRooms.length]);
+
+  const handleSelectAll = () => {
+    setSelectedFilter("all");
+    setOpenPopup(null);
+  };
+
+  const handleToggleRoom = (room: string) => {
+    setSelectedFilter("room");
+    setSelectedRooms((current) => (current.includes(room) ? current.filter((item) => item !== room) : [...current, room]));
+  };
+
+  const handleSelectDate = (date: number) => {
+    setSelectedFilter("date");
+    setSelectedDate(date);
+    setOpenPopup(null);
+  };
+
+  return (
+    <main className="bg-background min-h-0 flex-1 overflow-y-auto pb-28">
+      <header className="sticky top-0 z-20 bg-white pt-[max(1rem,env(safe-area-inset-top))] shadow-[0_1px_0_rgb(0_0_0_/_0.06)]">
+        <div className="flex h-12 items-center px-5">
+          <button type="button" onClick={onBack} className="touch-target-min -ml-3 flex items-center justify-center rounded-full">
+            <ArrowLeft className="size-5 text-[#222222]" aria-hidden />
+            <span className="sr-only">마이페이지로 돌아가기</span>
+          </button>
+          <h1 className="flex-1 text-center text-base font-bold text-[#111111]">저장된 데이트 코스</h1>
+          <span className="w-14 text-right text-xs font-semibold text-[#555555]">총 {formatCount(visibleCourses.length)}개</span>
+        </div>
+
+        <div className="relative flex gap-2 overflow-visible px-5 pb-3">
+          <button
+            type="button"
+            onClick={handleSelectAll}
+            className={cn(
+              "flex h-8 shrink-0 items-center rounded-full border px-4 text-xs font-semibold transition-colors",
+              selectedFilter === "all" ? "border-[#e6e6e6] bg-[#eeeeee] text-[#111111]" : "border-[#e5e5e5] bg-white text-[#222222] active:bg-[#f7f7f7]",
+            )}
+          >
+            전체
+          </button>
+
+          <div className="relative">
+            <button
+              type="button"
+              onClick={() => {
+                setSelectedFilter("room");
+                setOpenPopup((current) => (current === "room" ? null : "room"));
+              }}
+              className={cn(
+                "flex h-8 shrink-0 items-center gap-1 rounded-full border px-4 text-xs font-semibold transition-colors",
+                selectedFilter === "room" ? "border-[#e6e6e6] bg-[#eeeeee] text-[#111111]" : "border-[#e5e5e5] bg-white text-[#222222] active:bg-[#f7f7f7]",
+              )}
+            >
+              방
+              <ChevronDown className="size-3" aria-hidden />
+            </button>
+
+            {openPopup === "room" ? (
+              <div className="absolute left-0 top-10 z-30 w-52 rounded-lg border border-[#e8e8e8] bg-white py-2 shadow-[0_8px_24px_rgb(0_0_0_/_0.12)]">
+                {rooms.map((room) => {
+                  const checked = selectedRooms.includes(room);
+                  return (
+                    <label key={room} className="flex h-8 cursor-pointer items-center gap-2 px-3 text-xs font-medium text-[#222222]">
+                      <input
+                        type="checkbox"
+                        checked={checked}
+                        onChange={() => handleToggleRoom(room)}
+                        className="size-3 accent-[#111111]"
+                      />
+                      <span className="truncate">{room}</span>
+                    </label>
+                  );
+                })}
+              </div>
+            ) : null}
+          </div>
+
+          <div className="relative">
+            <button
+              type="button"
+              onClick={() => {
+                setSelectedFilter("date");
+                setOpenPopup((current) => (current === "date" ? null : "date"));
+              }}
+              className={cn(
+                "flex h-8 shrink-0 items-center gap-1 rounded-full border px-4 text-xs font-semibold transition-colors",
+                selectedFilter === "date" ? "border-[#e6e6e6] bg-[#eeeeee] text-[#111111]" : "border-[#e5e5e5] bg-white text-[#222222] active:bg-[#f7f7f7]",
+              )}
+            >
+              {formatDateLabel(selectedDate)}
+              <ChevronDown className="size-3" aria-hidden />
+            </button>
+
+            {openPopup === "date" ? (
+              <div className="absolute left-[-4.5rem] top-10 z-30 w-72 rounded-xl border border-[#e8e8e8] bg-white p-4 shadow-[0_10px_28px_rgb(0_0_0_/_0.14)]">
+                <div className="flex items-center justify-between">
+                  <strong className="text-sm font-bold text-[#222222]">April 2025</strong>
+                  <div className="flex gap-3 text-[#2684ff]">
+                    <ChevronLeft className="size-4" aria-hidden />
+                    <ChevronRight className="size-4" aria-hidden />
+                  </div>
+                </div>
+                <div className="mt-3 grid grid-cols-7 gap-y-3 text-center text-[0.65rem] font-semibold text-[#9a9a9a]">
+                  {['SUN', 'MON', 'TUE', 'WED', 'THU', 'FRI', 'SAT'].map((day) => (
+                    <span key={day}>{day}</span>
+                  ))}
+                </div>
+                <div className="mt-3 grid grid-cols-7 gap-y-2 text-center text-xs font-medium text-[#222222]">
+                  {aprilDates.map((date) => (
+                    <button
+                      key={date}
+                      type="button"
+                      onClick={() => handleSelectDate(date)}
+                      className={cn(
+                        "mx-auto flex size-7 items-center justify-center rounded-full",
+                        selectedDate === date ? "bg-[#dff1ff] font-bold text-[#1687e8]" : "active:bg-[#f3f3f3]",
+                      )}
+                    >
+                      {date}
+                    </button>
+                  ))}
+                </div>
+              </div>
+            ) : null}
+          </div>
+        </div>
+      </header>
+
+      <section className="px-5 pt-4">
+        {visibleCourses.length > 0 ? (
+          <div className="space-y-2">
+            {visibleCourses.map((course) => (
+              <SavedCourseCard key={course.id} course={course} onSelect={onSelectCourse} />
+            ))}
+          </div>
+        ) : (
+          <div className="flex min-h-[26rem] flex-col items-center justify-center text-center">
+            <span className="flex size-11 items-center justify-center rounded-full bg-[#777777] text-white">
+              <AlertCircle className="size-5" aria-hidden />
+            </span>
+            <p className="mt-4 text-sm font-medium text-[#8a8a8a]">해당하는 데이트 코스가 없습니다.</p>
+          </div>
+        )}
+      </section>
+    </main>
+  );
+}

--- a/src/components/mypage/SavedCourseSection.tsx
+++ b/src/components/mypage/SavedCourseSection.tsx
@@ -1,0 +1,52 @@
+﻿import type { SavedCourse } from "./mypage-mock-data";
+import { SavedCourseCard } from "./SavedCourseCard";
+
+type SavedCourseSectionProps = {
+  courses: SavedCourse[];
+  visibleCount: number;
+  onShowMore: () => void;
+  onShowAll: () => void;
+  onSelectCourse: (course: SavedCourse) => void;
+};
+
+export function SavedCourseSection({
+  courses,
+  visibleCount,
+  onShowMore,
+  onShowAll,
+  onSelectCourse,
+}: SavedCourseSectionProps) {
+  const visibleCourses = courses.slice(0, visibleCount);
+  const hasCourses = courses.length > 0;
+  const hasHiddenCourses = visibleCount < courses.length;
+  const actionLabel = hasHiddenCourses ? "5개 더보기" : "코스 전체보기";
+
+  return (
+    <section className="mt-6">
+      <h2 className="text-sm font-semibold text-[#111111]">저장된 데이트 코스</h2>
+
+      {hasCourses ? (
+        <>
+          <div className="mt-3 space-y-2">
+            {visibleCourses.map((course) => (
+              <SavedCourseCard key={course.id} course={course} onSelect={onSelectCourse} />
+            ))}
+          </div>
+
+          <button
+            type="button"
+            onClick={hasHiddenCourses ? onShowMore : onShowAll}
+            className="mt-3 flex h-9 w-full items-center justify-center rounded-lg border border-[#e8e8e8] bg-white text-xs font-semibold text-[#222222] active:bg-[#f7f7f7]"
+          >
+            {actionLabel}
+            <span className="ml-1 text-sm">⌄</span>
+          </button>
+        </>
+      ) : (
+        <div className="flex min-h-[16rem] items-center justify-center text-xs font-medium text-[#9a9a9a]">
+          데이트 코스를 저장해보세요!
+        </div>
+      )}
+    </section>
+  );
+}

--- a/src/components/mypage/SavedPlaceCategoryTabs.tsx
+++ b/src/components/mypage/SavedPlaceCategoryTabs.tsx
@@ -1,0 +1,45 @@
+﻿import { cn } from "@/lib/utils";
+
+import type { SavedPlaceCategory } from "./mypage-mock-data";
+
+export type SavedPlaceFilter = "all" | SavedPlaceCategory;
+
+const filters: { id: SavedPlaceFilter; label: string }[] = [
+  { id: "all", label: "전체" },
+  { id: "food", label: "맛집" },
+  { id: "cafe", label: "카페" },
+  { id: "activity", label: "놀거리" },
+  { id: "etc", label: "기타" },
+];
+
+type SavedPlaceCategoryTabsProps = {
+  selected: SavedPlaceFilter;
+  onSelect: (filter: SavedPlaceFilter) => void;
+};
+
+export function SavedPlaceCategoryTabs({ selected, onSelect }: SavedPlaceCategoryTabsProps) {
+  return (
+    <div className="scrollbar-hide flex gap-2 overflow-x-auto px-5 py-3" role="tablist" aria-label="장소 종류 필터">
+      {filters.map((filter) => {
+        const active = selected === filter.id;
+        return (
+          <button
+            key={filter.id}
+            type="button"
+            role="tab"
+            aria-selected={active}
+            onClick={() => onSelect(filter.id)}
+            className={cn(
+              "h-8 shrink-0 rounded-full border px-4 text-xs font-semibold transition-colors",
+              active
+                ? "border-[#e6e6e6] bg-[#e6e6e6] text-[#111111]"
+                : "border-[#e6e6e6] bg-white text-[#222222] active:bg-[#f7f7f7]",
+            )}
+          >
+            {filter.label}
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/components/mypage/SavedPlaceDetailPage.tsx
+++ b/src/components/mypage/SavedPlaceDetailPage.tsx
@@ -1,0 +1,80 @@
+import { ArrowLeft, ChevronDown, MapPin } from "lucide-react";
+
+import type { SavedPlace } from "./mypage-mock-data";
+
+type SavedPlaceDetailPageProps = {
+  place: SavedPlace;
+  onBack: () => void;
+};
+
+function getCategoryLabel(category: SavedPlace["category"]) {
+  const labels: Record<SavedPlace["category"], string> = {
+    food: "??",
+    cafe: "??",
+    activity: "???",
+    etc: "??",
+  };
+
+  return labels[category];
+}
+
+export function SavedPlaceDetailPage({ place, onBack }: SavedPlaceDetailPageProps) {
+  return (
+    <main className="bg-background min-h-0 flex-1 overflow-y-auto pb-28">
+      <section className="relative h-[27rem] overflow-hidden bg-[#eef3f5]">
+        <div className="absolute inset-0 bg-[linear-gradient(135deg,#eef1ec_0_25%,#ffffff_25%_50%,#e8f0f4_50%_75%,#ffffff_75%)] bg-[length:82px_82px]" />
+        <div className="absolute left-[-3rem] top-60 h-3 w-[32rem] rotate-[-9deg] rounded-full bg-[#2454b7]/75" />
+        <div className="absolute left-[-4rem] top-72 h-3 w-[34rem] rotate-[24deg] rounded-full bg-[#78bed2]/55" />
+        <span className="absolute left-[42%] top-44 flex size-8 items-center justify-center rounded-full border border-[#ef7773] bg-white text-[#ef7773] shadow-sm">
+          <MapPin className="size-5 fill-current" aria-hidden />
+        </span>
+
+        <div className="relative z-10 bg-[#ef7773] px-5 pb-4 pt-[max(2rem,env(safe-area-inset-top))] text-white">
+          <div className="flex items-center gap-2 text-base font-semibold">
+            <MapPin className="size-5 fill-white" aria-hidden />
+            <span>??? ??</span>
+          </div>
+        </div>
+      </section>
+
+      <section className="relative -mt-20 rounded-t-[1.75rem] bg-white px-5 pb-8 pt-4 shadow-[0_-12px_24px_rgb(0_0_0_/_0.06)]">
+        <div className="mx-auto mb-5 h-1 w-14 rounded-full bg-[#d4d4d4]" />
+
+        <div className="flex items-center gap-2">
+          <button type="button" onClick={onBack} className="touch-target-min -ml-2 flex items-center justify-center rounded-full">
+            <ArrowLeft className="size-5 text-[#222222]" aria-hidden />
+            <span className="sr-only">?? ??? ????</span>
+          </button>
+          <h1 className="min-w-0 flex-1 truncate text-lg font-bold text-[#111111]">{place.name}</h1>
+        </div>
+
+        <p className="mt-3 text-xs font-medium text-[#777777]">{place.address}</p>
+
+        <button
+          type="button"
+          className="mt-4 flex h-8 w-full items-center justify-center rounded-full border border-[#d8d8d8] bg-white text-xs font-semibold text-[#333333] active:bg-[#f7f7f7]"
+        >
+          ?? ?? ?? ????
+        </button>
+
+        <dl className="mt-5 space-y-3 text-xs text-[#333333]">
+          <div>
+            <dt className="font-semibold">?? ?</dt>
+            <dd className="mt-1 text-[#777777]">10:40 ??</dd>
+          </div>
+          <div>
+            <dt className="font-semibold">??? ?? ??</dt>
+            <dd className="mt-1 flex items-center gap-1 text-[#111111]">
+              <span>?(4/11) 10:40 ~ 19:30</span>
+              <ChevronDown className="size-3" aria-hidden />
+            </dd>
+          </div>
+          <div>
+            <dt className="font-semibold">??</dt>
+            <dd className="mt-1 text-[#777777]">{getCategoryLabel(place.category)}</dd>
+          </div>
+        </dl>
+      </section>
+    </main>
+  );
+}

--- a/src/components/mypage/SavedPlaceDetailPage.tsx
+++ b/src/components/mypage/SavedPlaceDetailPage.tsx
@@ -1,79 +1,106 @@
-import { ArrowLeft, ChevronDown, MapPin } from "lucide-react";
+import { ArrowLeft, ChevronDown, ExternalLink, MapPin } from "lucide-react";
 
 import type { SavedPlace } from "./mypage-mock-data";
+
+const TEXT = {
+  mapTitle: "\uB098\uB9CC\uC758 \uC9C0\uB3C4",
+  backToPlaces: "\uB098\uC758 \uC7A5\uC18C\uB85C \uB3CC\uC544\uAC00\uAE30",
+  reelsButton: "\uB0B4\uAC00 \uBD24\uB358 \uB9B4\uC2A4 \uB2E4\uC2DC\uBCF4\uAE30",
+  openedAt: "\uC601\uC5C5 \uC804 10:40 \uC624\uD508",
+  sharedBy: "\uACF5\uC720\uB41C \uC7A5\uC18C \uC601\uC5C5",
+  todayHours: "\uD1A0(4/11) 10:40 ~ 19:30",
+  category: "\uC885\uB958",
+} as const;
+
+function getCategoryLabel(category: SavedPlace["category"]) {
+  const labels: Record<SavedPlace["category"], string> = {
+    food: "\uB9DB\uC9D1",
+    cafe: "\uCE74\uD398",
+    activity: "\uB180\uAC70\uB9AC",
+    etc: "\uAE30\uD0C0",
+  };
+
+  return labels[category];
+}
 
 type SavedPlaceDetailPageProps = {
   place: SavedPlace;
   onBack: () => void;
 };
 
-function getCategoryLabel(category: SavedPlace["category"]) {
-  const labels: Record<SavedPlace["category"], string> = {
-    food: "??",
-    cafe: "??",
-    activity: "???",
-    etc: "??",
-  };
-
-  return labels[category];
-}
-
 export function SavedPlaceDetailPage({ place, onBack }: SavedPlaceDetailPageProps) {
   return (
     <main className="bg-background min-h-0 flex-1 overflow-y-auto pb-28">
-      <section className="relative h-[27rem] overflow-hidden bg-[#eef3f5]">
-        <div className="absolute inset-0 bg-[linear-gradient(135deg,#eef1ec_0_25%,#ffffff_25%_50%,#e8f0f4_50%_75%,#ffffff_75%)] bg-[length:82px_82px]" />
-        <div className="absolute left-[-3rem] top-60 h-3 w-[32rem] rotate-[-9deg] rounded-full bg-[#2454b7]/75" />
-        <div className="absolute left-[-4rem] top-72 h-3 w-[34rem] rotate-[24deg] rounded-full bg-[#78bed2]/55" />
-        <span className="absolute left-[42%] top-44 flex size-8 items-center justify-center rounded-full border border-[#ef7773] bg-white text-[#ef7773] shadow-sm">
-          <MapPin className="size-5 fill-current" aria-hidden />
-        </span>
+      <section className="relative min-h-[calc(100dvh-5.5rem)] overflow-hidden bg-white">
+        <div className="relative h-[29rem] overflow-hidden bg-[#eef3f5]">
+          <div className="absolute inset-0 bg-[linear-gradient(135deg,#eef1ec_0_25%,#ffffff_25%_50%,#e8f0f4_50%_75%,#ffffff_75%)] bg-[length:82px_82px]" />
+          <div className="absolute left-[-4rem] top-72 h-3 w-[34rem] rotate-[-9deg] rounded-full bg-[#2454b7]/75" />
+          <div className="absolute left-[-5rem] top-64 h-3 w-[36rem] rotate-[24deg] rounded-full bg-[#78bed2]/55" />
+          <div className="absolute left-10 top-60 h-12 w-20 rounded-full bg-[#f7d9a3]/45 blur-sm" />
+          <div className="absolute right-2 top-32 h-20 w-24 rounded-full bg-[#d7eadb]/65 blur-sm" />
 
-        <div className="relative z-10 bg-[#ef7773] px-5 pb-4 pt-[max(2rem,env(safe-area-inset-top))] text-white">
-          <div className="flex items-center gap-2 text-base font-semibold">
-            <MapPin className="size-5 fill-white" aria-hidden />
-            <span>??? ??</span>
+          {[
+            "left-[22%] top-[48%]",
+            "left-[50%] top-[35%]",
+            "right-[18%] top-[54%]",
+          ].map((position) => (
+            <span
+              key={position}
+              className={`absolute ${position} flex size-8 items-center justify-center rounded-full border border-[#ef7773] bg-white text-[#ef7773] shadow-sm`}
+            >
+              <MapPin className="size-5 fill-current" aria-hidden />
+            </span>
+          ))}
+
+          <div className="relative z-10 bg-[#ef7773] px-5 pb-4 pt-[max(2rem,env(safe-area-inset-top))] text-white">
+            <div className="flex items-center gap-2 text-base font-semibold">
+              <MapPin className="size-5 fill-white" aria-hidden />
+              <span>{TEXT.mapTitle}</span>
+            </div>
           </div>
         </div>
-      </section>
 
-      <section className="relative -mt-20 rounded-t-[1.75rem] bg-white px-5 pb-8 pt-4 shadow-[0_-12px_24px_rgb(0_0_0_/_0.06)]">
-        <div className="mx-auto mb-5 h-1 w-14 rounded-full bg-[#d4d4d4]" />
+        <section className="relative -mt-24 rounded-t-[1.75rem] bg-white px-5 pb-8 pt-4 shadow-[0_-12px_24px_rgb(0_0_0_/_0.06)]">
+          <div className="mx-auto mb-5 h-1 w-14 rounded-full bg-[#d4d4d4]" />
 
-        <div className="flex items-center gap-2">
-          <button type="button" onClick={onBack} className="touch-target-min -ml-2 flex items-center justify-center rounded-full">
-            <ArrowLeft className="size-5 text-[#222222]" aria-hidden />
-            <span className="sr-only">?? ??? ????</span>
+          <div className="flex items-center gap-2">
+            <button type="button" onClick={onBack} className="touch-target-min -ml-2 flex items-center justify-center rounded-full">
+              <ArrowLeft className="size-5 text-[#222222]" aria-hidden />
+              <span className="sr-only">{TEXT.backToPlaces}</span>
+            </button>
+            <h1 className="min-w-0 flex-1 truncate text-lg font-bold text-[#111111]">{place.name}</h1>
+          </div>
+
+          <p className="mt-2 text-xs font-medium leading-relaxed text-[#777777]">{place.address}</p>
+
+          <button
+            type="button"
+            className="mt-4 flex h-8 w-full items-center justify-center gap-1 rounded-full border border-[#d8d8d8] bg-white text-xs font-semibold text-[#333333] active:bg-[#f7f7f7]"
+          >
+            <span>{TEXT.reelsButton}</span>
+            <ExternalLink className="size-3" aria-hidden />
           </button>
-          <h1 className="min-w-0 flex-1 truncate text-lg font-bold text-[#111111]">{place.name}</h1>
-        </div>
 
-        <p className="mt-3 text-xs font-medium text-[#777777]">{place.address}</p>
-
-        <button
-          type="button"
-          className="mt-4 flex h-8 w-full items-center justify-center rounded-full border border-[#d8d8d8] bg-white text-xs font-semibold text-[#333333] active:bg-[#f7f7f7]"
-        >
-          ?? ?? ?? ????
-        </button>
-
-        <dl className="mt-5 space-y-3 text-xs text-[#333333]">
-          <div>
-            <dt className="font-semibold">?? ?</dt>
-            <dd className="mt-1 text-[#777777]">10:40 ??</dd>
-          </div>
-          <div>
-            <dt className="font-semibold">??? ?? ??</dt>
-            <dd className="mt-1 flex items-center gap-1 text-[#111111]">
-              <span>?(4/11) 10:40 ~ 19:30</span>
-              <ChevronDown className="size-3" aria-hidden />
-            </dd>
-          </div>
-          <div>
-            <dt className="font-semibold">??</dt>
-            <dd className="mt-1 text-[#777777]">{getCategoryLabel(place.category)}</dd>
-          </div>
-        </dl>
+          <dl className="mt-5 space-y-3 text-xs text-[#333333]">
+            <div>
+              <dt className="font-semibold">{TEXT.openedAt}</dt>
+              <dd className="mt-1 text-[#777777]">{TEXT.sharedBy}</dd>
+            </div>
+            <div>
+              <dt className="sr-only">\uC624\uB298 \uC601\uC5C5\uC2DC\uAC04</dt>
+              <dd className="mt-1 flex items-center gap-1 font-semibold text-[#111111]">
+                <span>{TEXT.todayHours}</span>
+                <ChevronDown className="size-3" aria-hidden />
+              </dd>
+            </div>
+            <div>
+              <dt className="sr-only">{TEXT.category}</dt>
+              <dd className="inline-flex rounded-full bg-[#f8eeee] px-2 py-1 text-[0.68rem] font-semibold text-[#ef7773]">
+                {getCategoryLabel(place.category)}
+              </dd>
+            </div>
+          </dl>
+        </section>
       </section>
     </main>
   );

--- a/src/components/mypage/SavedPlaceItem.tsx
+++ b/src/components/mypage/SavedPlaceItem.tsx
@@ -1,0 +1,79 @@
+﻿import { MoreVertical } from "lucide-react";
+
+import type { SavedPlace } from "./mypage-mock-data";
+import { SavedPlaceMemoEditor } from "./SavedPlaceMemoEditor";
+
+type SavedPlaceItemProps = {
+  place: SavedPlace;
+  isMenuOpen: boolean;
+  isEditing: boolean;
+  memoDraft: string;
+  onToggleMenu: (id: string) => void;
+  onStartMemo: (place: SavedPlace) => void;
+  onChangeMemo: (value: string) => void;
+  onSaveMemo: () => void;
+  onClearMemo: () => void;
+  onDelete: (id: string) => void;
+  onSelect: (place: SavedPlace) => void;
+};
+
+export function SavedPlaceItem({
+  place,
+  isMenuOpen,
+  isEditing,
+  memoDraft,
+  onToggleMenu,
+  onStartMemo,
+  onChangeMemo,
+  onSaveMemo,
+  onClearMemo,
+  onDelete,
+  onSelect,
+}: SavedPlaceItemProps) {
+  return (
+    <article className="relative rounded-lg border border-[#e8e8e8] bg-white px-3 py-3">
+      <div className="flex gap-3">
+        <button type="button" onClick={() => onSelect(place)} className="min-w-0 flex-1 text-left">
+          <h3 className="truncate text-sm font-semibold text-[#222222]">{place.name}</h3>
+          <p className="mt-1 truncate text-[0.68rem] font-medium text-[#777777]">{place.address}</p>
+        </button>
+
+        <button
+          type="button"
+          onClick={() => onToggleMenu(place.id)}
+          className="touch-target-min -mr-2 -mt-2 flex shrink-0 items-center justify-center rounded-full text-[#222222]"
+        >
+          <MoreVertical className="size-4" aria-hidden />
+          <span className="sr-only">장소 메뉴 열기</span>
+        </button>
+      </div>
+
+      {place.memo && !isEditing ? (
+        <p className="mt-2 rounded-md bg-[#ffecea] px-3 py-2 text-xs font-medium text-[#333333]">{place.memo}</p>
+      ) : null}
+
+      {isEditing ? (
+        <SavedPlaceMemoEditor value={memoDraft} onChange={onChangeMemo} onSave={onSaveMemo} onClear={onClearMemo} />
+      ) : null}
+
+      {isMenuOpen ? (
+        <div className="absolute right-8 top-9 z-10 w-24 overflow-hidden rounded-md border border-[#e5e5e5] bg-white shadow-[0_8px_20px_rgb(0_0_0_/_0.12)]">
+          <button
+            type="button"
+            onClick={() => onStartMemo(place)}
+            className="block w-full px-4 py-2 text-left text-xs font-medium text-[#222222] active:bg-[#f7f7f7]"
+          >
+            메모
+          </button>
+          <button
+            type="button"
+            onClick={() => onDelete(place.id)}
+            className="block w-full px-4 py-2 text-left text-xs font-medium text-[#222222] active:bg-[#f7f7f7]"
+          >
+            삭제
+          </button>
+        </div>
+      ) : null}
+    </article>
+  );
+}

--- a/src/components/mypage/SavedPlaceMemoEditor.tsx
+++ b/src/components/mypage/SavedPlaceMemoEditor.tsx
@@ -1,0 +1,39 @@
+﻿import { X } from "lucide-react";
+
+const MAX_MEMO_LENGTH = 50;
+
+type SavedPlaceMemoEditorProps = {
+  value: string;
+  onChange: (value: string) => void;
+  onSave: () => void;
+  onClear: () => void;
+};
+
+export function SavedPlaceMemoEditor({ value, onChange, onSave, onClear }: SavedPlaceMemoEditorProps) {
+  return (
+    <div className="mt-2 flex items-center rounded-md border border-[#7da4ff] bg-white px-3 py-1.5">
+      <input
+        type="text"
+        value={value}
+        maxLength={MAX_MEMO_LENGTH}
+        onChange={(event) => onChange(event.target.value)}
+        onBlur={onSave}
+        onKeyDown={(event) => {
+          if (event.key === "Enter") {
+            event.currentTarget.blur();
+          }
+        }}
+        className="min-w-0 flex-1 bg-transparent text-xs font-medium text-[#222222] outline-none placeholder:text-[#9a9a9a]"
+        placeholder="메모를 남겨주세요."
+        autoFocus
+      />
+      {value ? (
+        <button type="button" onMouseDown={(event) => event.preventDefault()} onClick={onClear} className="ml-2 text-[#777777]">
+          <X className="size-3.5" aria-hidden />
+          <span className="sr-only">메모 지우기</span>
+        </button>
+      ) : null}
+      <span className="ml-2 text-[0.6rem] font-medium text-[#777777]">{value.length}/50</span>
+    </div>
+  );
+}

--- a/src/components/mypage/mypage-mock-data.ts
+++ b/src/components/mypage/mypage-mock-data.ts
@@ -1,0 +1,173 @@
+﻿export type SavedPlaceCategory = "food" | "cafe" | "activity" | "etc";
+
+export type RecentPlace = {
+  id: string;
+  name: string;
+};
+
+export type SavedPlace = {
+  id: string;
+  name: string;
+  address: string;
+  category: SavedPlaceCategory;
+  memo?: string;
+};
+
+export type SavedCourse = {
+  id: string;
+  title: string;
+  executedAtLabel: string;
+  badgeLabel: string;
+  stops: CourseStop[];
+};
+
+export type CourseStop = {
+  id: string;
+  name: string;
+  address: string;
+  walkingTime?: string;
+  hours?: string;
+};
+
+export const myPageUser = {
+  nickname: "홍길동",
+  savedPlaceCount: 58,
+  recentPlaces: [
+    { id: "place-recent-1", name: "아임파이" },
+    { id: "place-recent-2", name: "투썸플레이스" },
+  ],
+};
+
+export const savedPlaces: SavedPlace[] = [
+  {
+    id: "place-1",
+    name: "아임파이",
+    address: "서울 동대문구 회기로 116-1 2층 (회기동)",
+    category: "cafe",
+  },
+  {
+    id: "place-2",
+    name: "감동",
+    address: "서울 동대문구 회기로 25길 101-13 1층",
+    category: "food",
+    memo: "커피 완전 맛있음 ★★★",
+  },
+  {
+    id: "place-3",
+    name: "한국외국어대학교 서울캠퍼스",
+    address: "서울 동대문구 회기로 116-1 2층 (회기동)",
+    category: "etc",
+  },
+  {
+    id: "place-4",
+    name: "언니네함박그",
+    address: "서울 동대문구 회기로25길 59 1층 언니네함박그",
+    category: "food",
+  },
+  {
+    id: "place-5",
+    name: "무감커피바",
+    address: "서울 동대문구 회기로21길 19 지하1층",
+    category: "cafe",
+  },
+  {
+    id: "place-6",
+    name: "호현장담 외대후문점",
+    address: "서울 동대문구 천장산로7길 10-1 2층 호현장담",
+    category: "activity",
+  },
+];
+
+export const savedCourses: SavedCourse[] = [
+  {
+    id: "course-1",
+    title: "서울 동대문구 0408",
+    executedAtLabel: "2일 전 실행한 코스",
+    badgeLabel: "친구",
+    stops: [
+      {
+        id: "stop-1",
+        name: "한국외국어대학교 서울캠퍼스",
+        address: "서울 동대문구 이문로 107",
+        walkingTime: "도보 10분",
+      },
+      {
+        id: "stop-2",
+        name: "감동",
+        address: "회기로 25길 101-13 1층",
+        walkingTime: "도보 10분",
+      },
+      {
+        id: "stop-3",
+        name: "샤로스톤 외대점",
+        address: "회기로 27",
+      },
+    ],
+  },
+  {
+    id: "course-2",
+    title: "망원동 벚꽃데이트 코스",
+    executedAtLabel: "7일 전 실행한 코스",
+    badgeLabel: "하트",
+    stops: [
+      {
+        id: "stop-4",
+        name: "망원시장",
+        address: "서울 마포구 포은로8길 14",
+        walkingTime: "도보 8분",
+      },
+      {
+        id: "stop-5",
+        name: "망원한강공원",
+        address: "서울 마포구 마포나루길 467",
+      },
+    ],
+  },
+  {
+    id: "course-3",
+    title: "간만에 휴가 데이트",
+    executedAtLabel: "03.08 실행한 코스",
+    badgeLabel: "하트",
+    stops: [
+      {
+        id: "stop-6",
+        name: "연남동 산책길",
+        address: "서울 마포구 연남동",
+        walkingTime: "도보 12분",
+      },
+      {
+        id: "stop-7",
+        name: "작은 카페",
+        address: "서울 마포구 동교로 41길",
+      },
+    ],
+  },
+  {
+    id: "course-4",
+    title: "간만에 휴가 데이트",
+    executedAtLabel: "03.08 실행한 코스",
+    badgeLabel: "하트",
+    stops: [{ id: "stop-8", name: "성수 카페거리", address: "서울 성동구 성수동" }],
+  },
+  {
+    id: "course-5",
+    title: "간만에 휴가 데이트",
+    executedAtLabel: "03.08 실행한 코스",
+    badgeLabel: "하트",
+    stops: [{ id: "stop-9", name: "서울숲", address: "서울 성동구 뚝섬로 273" }],
+  },
+  {
+    id: "course-6",
+    title: "간만에 휴가 데이트",
+    executedAtLabel: "03.08 실행한 코스",
+    badgeLabel: "하트",
+    stops: [{ id: "stop-10", name: "뚝섬 한강공원", address: "서울 광진구 강변북로 139" }],
+  },
+  {
+    id: "course-7",
+    title: "간만에 휴가 데이트",
+    executedAtLabel: "03.08 실행한 코스",
+    badgeLabel: "하트",
+    stops: [{ id: "stop-11", name: "압구정 로데오", address: "서울 강남구 압구정로" }],
+  },
+];

--- a/src/pages/tabs/MyPage.tsx
+++ b/src/pages/tabs/MyPage.tsx
@@ -1,13 +1,102 @@
+﻿import { useState } from "react";
+
 import { BottomNavigationBar } from "@/components/common/BottomNavigationBar";
 import { BottomNavToast } from "@/components/common/BottomNavToast";
+import { MyAccountActions } from "@/components/mypage/MyAccountActions";
+import {
+  myPageUser,
+  savedCourses,
+  savedPlaces as initialSavedPlaces,
+  type SavedCourse,
+  type SavedPlace,
+} from "@/components/mypage/mypage-mock-data";
+import { MyPageCourseDetail } from "@/components/mypage/MyPageCourseDetail";
+import { SavedCourseListPage } from "@/components/mypage/SavedCourseListPage";
+import { SavedPlaceDetailPage } from "@/components/mypage/SavedPlaceDetailPage";
+import { MyPlaceSummaryCard } from "@/components/mypage/MyPlaceSummaryCard";
+import { MyProfileHeader } from "@/components/mypage/MyProfileHeader";
+import { MySavedPlacesPage } from "@/components/mypage/MySavedPlacesPage";
+import { SavedCourseSection } from "@/components/mypage/SavedCourseSection";
 import { useBottomNavController } from "@/hooks/use-bottom-nav-controller";
+
+type MyPageView = "main" | "places" | "courses";
 
 export function MyPage() {
   const { toastMessage, handleSelectBottomNav } = useBottomNavController();
+  const [view, setView] = useState<MyPageView>("main");
+  const [visibleCourseCount, setVisibleCourseCount] = useState(5);
+  const [selectedCourse, setSelectedCourse] = useState<SavedCourse | null>(null);
+  const [selectedPlace, setSelectedPlace] = useState<SavedPlace | null>(null);
+  const [places, setPlaces] = useState<SavedPlace[]>(initialSavedPlaces);
+
+  const handleShowMoreCourses = () => {
+    setVisibleCourseCount((count) => Math.min(count + 5, savedCourses.length));
+  };
+
+  if (selectedCourse) {
+    return (
+      <div className="-m-page relative flex min-h-0 flex-1 flex-col overflow-hidden">
+        <MyPageCourseDetail course={selectedCourse} onBack={() => setSelectedCourse(null)} />
+        <BottomNavToast message={toastMessage} />
+        <BottomNavigationBar activeId="mypage" onSelect={handleSelectBottomNav} />
+      </div>
+    );
+  }
+
+  if (selectedPlace) {
+    return (
+      <div className="-m-page relative flex min-h-0 flex-1 flex-col overflow-hidden">
+        <SavedPlaceDetailPage place={selectedPlace} onBack={() => setSelectedPlace(null)} />
+        <BottomNavToast message={toastMessage} />
+        <BottomNavigationBar activeId="mypage" onSelect={handleSelectBottomNav} />
+      </div>
+    );
+  }
+
+  if (view === "places") {
+    return (
+      <div className="-m-page relative flex min-h-0 flex-1 flex-col overflow-hidden">
+        <MySavedPlacesPage places={places} onBack={() => setView("main")} onChangePlaces={setPlaces} onSelectPlace={setSelectedPlace} />
+        <BottomNavToast message={toastMessage} />
+        <BottomNavigationBar activeId="mypage" onSelect={handleSelectBottomNav} />
+      </div>
+    );
+  }
+
+  if (view === "courses") {
+    return (
+      <div className="-m-page relative flex min-h-0 flex-1 flex-col overflow-hidden">
+        <SavedCourseListPage courses={savedCourses} onBack={() => setView("main")} onSelectCourse={setSelectedCourse} />
+        <BottomNavToast message={toastMessage} />
+        <BottomNavigationBar activeId="mypage" onSelect={handleSelectBottomNav} />
+      </div>
+    );
+  }
 
   return (
     <div className="-m-page relative flex min-h-0 flex-1 flex-col overflow-hidden">
-      <main className="bg-background min-h-0 flex-1" />
+      <main className="bg-background min-h-0 flex-1 overflow-y-auto pb-28">
+        <MyProfileHeader nickname={myPageUser.nickname} />
+
+        <div className="px-5 pt-5">
+          <MyPlaceSummaryCard
+            totalCount={places.length}
+            recentPlaces={places.slice(0, 2).map((place) => ({ id: place.id, name: place.name }))}
+            onOpenPlaces={() => setView("places")}
+          />
+
+          <SavedCourseSection
+            courses={savedCourses}
+            visibleCount={visibleCourseCount}
+            onShowMore={handleShowMoreCourses}
+            onShowAll={() => setView("courses")}
+            onSelectCourse={setSelectedCourse}
+          />
+
+          <MyAccountActions />
+        </div>
+      </main>
+
       <BottomNavToast message={toastMessage} />
       <BottomNavigationBar activeId="mypage" onSelect={handleSelectBottomNav} />
     </div>


### PR DESCRIPTION
## ✨ 무엇을 바꿨나요?

마이페이지 메인 화면과 저장 장소/저장 데이트 코스 관련 프론트 UI를 구현했습니다.  
요약 카드, 리스트, 예외 상태, 상세 화면, 메모 UI까지 mock 데이터 기반으로 확인할 수 있도록 구성했습니다.

## 🔗 관련 이슈

Closes #6

## 💡 왜 바꿨나요?

사용자가 저장한 장소와 저장한 데이트 코스를 한 화면에서 확인하고, 관련 상세 화면 흐름을 프론트에서 먼저 검증할 수 있도록 하기 위해 구현했습니다.

## 📝 주요 변경 사항

- 마이페이지 메인 화면 UI 구현
- 나의 장소 요약 카드 UI 구현
- 저장된 데이트 코스 리스트 UI 구현
- 나의 장소 전체보기 UI 구현
- 저장 장소 메모 작성/수정/삭제 UI 구현
- 저장 장소 없음 / 필터 결과 없음 상태 UI 구현
- 저장 코스 전체보기 UI 구현
- 저장 코스 상세 화면 UI 구현
- `/dev/mypage` 임시 확인 경로 추가

## 👀 리뷰어가 보면 좋은 부분

- 마이페이지 메인/상세/예외 상태 분리 방식
- 저장 장소 메모 UI 처리 구조

## 🧪 테스트

**방식** (해당하는 것만 체크)

- [o] 로컬 환경에서 확인
- [ ] 운영 환경에서 확인
- [ ] 단위 / 통합 테스트
- [ ] 해당 없음

**메모** (시나리오, 커맨드, 스크린샷 링크 등 — 선택)

- `npm run dev`
- `http://localhost:5173/dev/mypage` 에서 메인/예외/상세 화면 확인
- API 연결 없이 mock 데이터 기반으로 UI 확인
