### PR TITLE
feat: 데이트 코스짜기 카테고리 및 순서 설정 UI 수정 및 추가

### DIFF
--- a/src/app/router/index.tsx
+++ b/src/app/router/index.tsx
@@ -13,6 +13,7 @@ import { mapHomeLoader } from "@/pages/map/map-home-loader";
 import NicknamePage from "@/pages/onboarding/NicknamePage";
 import TermsAgreementPage from "@/pages/onboarding/TermsAgreementPage";
 import SplashScreenPage from "@/pages/SplashScreenPage";
+import CoursePlannerPagePreview from "@/pages/tabs/CoursePlannerPage";
 
 const MapHomePage = lazy(() => import("@/pages/MapHomePage"));
 const RoomMainPage = lazy(() => import("@/pages/room/RoomMainPage"));
@@ -30,7 +31,7 @@ export const router = createBrowserRouter([
       { path: "dev/click_place", element: <DevClickPlacePage /> },
       { path: "dev/SelectOption", element: <DevSelectOptionPage /> },
       { path: "login", element: <LoginPage /> },
-      { path: "dev/course", element: <CoursePlannerPage skipRoomGuard /> },
+      { path: "dev/course", element: <CoursePlannerPagePreview skipRoomGuard /> },
       { path: "app", element: <Navigate to="/" replace /> },
       {
         path: "auth/callback",

--- a/src/components/course-planner/CoursePlannerPanel.tsx
+++ b/src/components/course-planner/CoursePlannerPanel.tsx
@@ -1,38 +1,68 @@
-﻿import { CalendarDays, Coffee, Flag, MoreHorizontal, Utensils } from "lucide-react";
+import { CalendarDays, Coffee, Flag, Plus, Utensils } from "lucide-react";
 
 import { CoursePlannerActions } from "@/components/course-planner/CoursePlannerActions";
 import { CoursePlannerField } from "@/components/course-planner/CoursePlannerField";
 import { PlaceTypeChip } from "@/components/course-planner/PlaceTypeChip";
+import { cn } from "@/lib/utils";
 
-export type PlaceTypeId = "restaurant" | "cafe" | "activity" | "etc";
+export type PlaceTypeId = "restaurant" | "cafe" | "activity";
+
+export type CourseCategoryOrder = {
+  id: number;
+  category: PlaceTypeId;
+  tags: string[];
+};
 
 type CoursePlannerPanelProps = {
   regionValue: string;
   dateTimeValue: string;
-  selectedPlaceTypeIds: PlaceTypeId[];
+  courseOrders: CourseCategoryOrder[];
   canGenerate: boolean;
   onOpenRegionSelect: () => void;
   onOpenDateTimeSelect: () => void;
-  onTogglePlaceType: (placeTypeId: PlaceTypeId) => void;
+  onCreateFirstOrder: (placeTypeId: PlaceTypeId) => void;
+  onAddOrder: () => void;
+  onSelectOrderCategory: (orderId: number, placeTypeId: PlaceTypeId) => void;
+  onToggleOrderTag: (orderId: number, tag: string) => void;
   onGenerate: () => void;
   onReset: () => void;
 };
 
 const placeTypes: Array<{ id: PlaceTypeId; label: string; icon: React.ReactNode }> = [
-  { id: "restaurant", label: "맛집", icon: <Utensils className="size-3.5" /> },
+  { id: "restaurant", label: "음식점", icon: <Utensils className="size-3.5" /> },
   { id: "cafe", label: "카페", icon: <Coffee className="size-3.5" /> },
   { id: "activity", label: "놀거리", icon: <Flag className="size-3.5" /> },
-  { id: "etc", label: "기타", icon: <MoreHorizontal className="size-3.5" /> },
 ];
+
+const categoryTags: Record<PlaceTypeId, string[]> = {
+  restaurant: ["한식", "중식", "일식", "양식", "분식", "아시아식", "술집", "기타"],
+  cafe: ["제과, 베이커리", "디저트 카페", "브런치 카페", "루프탑 카페", "보드카페", "만화카페"],
+  activity: [
+    "테마파크",
+    "보드카페",
+    "만화카페",
+    "문화,예술",
+    "방탈출카페",
+    "스포츠",
+    "찜질방",
+    "공원",
+    "생활용품점",
+    "아쿠아리움",
+    "기타",
+  ],
+};
 
 export function CoursePlannerPanel({
   regionValue,
   dateTimeValue,
-  selectedPlaceTypeIds,
+  courseOrders,
   canGenerate,
   onOpenRegionSelect,
   onOpenDateTimeSelect,
-  onTogglePlaceType,
+  onCreateFirstOrder,
+  onAddOrder,
+  onSelectOrderCategory,
+  onToggleOrderTag,
   onGenerate,
   onReset,
 }: CoursePlannerPanelProps) {
@@ -58,18 +88,80 @@ export function CoursePlannerPanel({
         />
 
         <div className="grid gap-2">
-          <span className="text-sm font-semibold text-[#171717]">장소 종류</span>
-          <div className="flex flex-wrap gap-2">
-            {placeTypes.map((type) => (
-              <PlaceTypeChip
-                key={type.id}
-                label={type.label}
-                icon={type.icon}
-                selected={selectedPlaceTypeIds.includes(type.id)}
-                onClick={() => onTogglePlaceType(type.id)}
-              />
-            ))}
+          <div className="flex items-center justify-between">
+            <span className="text-sm font-semibold text-[#171717]">
+              데이트 카테고리 및 순서 설정
+              <span className="ml-0.5 text-[#f06f6b]">*</span>
+            </span>
+
+            {courseOrders.length > 0 ? (
+              <button
+                type="button"
+                onClick={onAddOrder}
+                className="inline-flex size-7 items-center justify-center rounded-full text-[#5f6368] transition-colors hover:bg-[#f4f4f5] focus-visible:outline-none focus-visible:ring-3 focus-visible:ring-ring/50"
+                aria-label="순서 추가"
+              >
+                <Plus className="size-4" aria-hidden />
+              </button>
+            ) : null}
           </div>
+
+          {courseOrders.length === 0 ? (
+            <div className="flex flex-wrap gap-2">
+              {placeTypes.map((type) => (
+                <PlaceTypeChip
+                  key={type.id}
+                  label={type.label}
+                  icon={type.icon}
+                  onClick={() => onCreateFirstOrder(type.id)}
+                />
+              ))}
+            </div>
+          ) : (
+            <div className="grid gap-3">
+              {courseOrders.map((order, index) => (
+                <div key={order.id} className="rounded-[20px] border border-[#e7e5e4] bg-white px-3 py-3.5">
+                  <span className="inline-flex size-6 items-center justify-center rounded-full bg-[#f4a09a] text-[0.68rem] font-bold text-white">
+                    {index + 1}
+                  </span>
+
+                  <div className="mt-3 flex flex-wrap gap-2">
+                    {placeTypes.map((type) => (
+                      <PlaceTypeChip
+                        key={type.id}
+                        label={type.label}
+                        icon={type.icon}
+                        selected={order.category === type.id}
+                        selectedStyle="muted"
+                        onClick={() => onSelectOrderCategory(order.id, type.id)}
+                      />
+                    ))}
+                  </div>
+
+                  <div className="mt-3 flex flex-wrap gap-2 rounded-2xl border border-[#ececec] bg-[#fafafa] p-3">
+                    {categoryTags[order.category].map((tag) => {
+                      const selected = order.tags.includes(tag);
+                      return (
+                        <button
+                          key={tag}
+                          type="button"
+                          onClick={() => onToggleOrderTag(order.id, tag)}
+                          className={cn(
+                            "rounded-full border px-3 py-1.5 text-xs font-medium transition-colors focus-visible:outline-none focus-visible:ring-3 focus-visible:ring-ring/50",
+                            selected
+                              ? "border-[#f4a09a] bg-[#fff0ee] text-[#d95f5b]"
+                              : "border-[#dfdfdf] bg-white text-[#5f6368] hover:bg-[#f8f8f8]",
+                          )}
+                        >
+                          {tag}
+                        </button>
+                      );
+                    })}
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
         </div>
       </div>
 

--- a/src/components/course-planner/PlaceTypeChip.tsx
+++ b/src/components/course-planner/PlaceTypeChip.tsx
@@ -1,4 +1,4 @@
-﻿import type { ReactNode } from "react";
+import type { ReactNode } from "react";
 
 import { cn } from "@/lib/utils";
 
@@ -6,10 +6,21 @@ type PlaceTypeChipProps = {
   label: string;
   icon: ReactNode;
   selected?: boolean;
+  selectedStyle?: "accent" | "muted";
   onClick?: () => void;
 };
 
-export function PlaceTypeChip({ label, icon, selected = false, onClick }: PlaceTypeChipProps) {
+export function PlaceTypeChip({
+  label,
+  icon,
+  selected = false,
+  selectedStyle = "accent",
+  onClick,
+}: PlaceTypeChipProps) {
+  const selectedClassName = selectedStyle === "muted"
+    ? "border-[#d9d9d9] bg-[#f1f1f1] text-[#4b5563]"
+    : "border-[#f06f6b] bg-[#fff0ee] text-[#d95f5b]";
+
   return (
     <button
       type="button"
@@ -18,7 +29,7 @@ export function PlaceTypeChip({ label, icon, selected = false, onClick }: PlaceT
       className={cn(
         "inline-flex h-8 items-center gap-1.5 rounded-lg border px-3 text-xs font-medium transition-colors focus-visible:outline-none focus-visible:ring-3 focus-visible:ring-ring/50",
         selected
-          ? "border-[#f06f6b] bg-[#fff0ee] text-[#d95f5b]"
+          ? selectedClassName
           : "border-[#e5e7eb] bg-white text-[#4b5563] hover:bg-[#fafafa]",
       )}
     >

--- a/src/pages/tabs/CoursePlannerPage.tsx
+++ b/src/pages/tabs/CoursePlannerPage.tsx
@@ -7,7 +7,11 @@ import { CourseEditPanel } from "@/components/course-planner/CourseEditPanel";
 import { CourseGenerationLoadingPanel } from "@/components/course-planner/CourseGenerationLoadingPanel";
 import { CoursePlaceInfoPanel, type CourseStop } from "@/components/course-planner/CoursePlaceInfoPanel";
 import { CoursePlannerMapPreview } from "@/components/course-planner/CoursePlannerMapPreview";
-import { CoursePlannerPanel, type PlaceTypeId } from "@/components/course-planner/CoursePlannerPanel";
+import {
+  CoursePlannerPanel,
+  type CourseCategoryOrder,
+  type PlaceTypeId,
+} from "@/components/course-planner/CoursePlannerPanel";
 import { CourseResultPanel, type CourseOption } from "@/components/course-planner/CourseResultPanel";
 import {
   DateTimeSelectionPanel,
@@ -68,7 +72,7 @@ export default function CoursePlannerPage({ skipRoomGuard = false }: CoursePlann
   const [draftDate, setDraftDate] = useState("2026.04.20");
   const [draftStartTime, setDraftStartTime] = useState<string | null>("13:00");
   const [draftEndTime, setDraftEndTime] = useState<string | null>("21:00");
-  const [selectedPlaceTypeIds, setSelectedPlaceTypeIds] = useState<PlaceTypeId[]>(["restaurant"]);
+  const [courseOrders, setCourseOrders] = useState<CourseCategoryOrder[]>([]);
   const [selectedCourseId, setSelectedCourseId] = useState(mockCourses[0]?.id ?? "");
   const [courseTitle, setCourseTitle] = useState(mockCourses[0]?.title ?? "코스 1");
   const [courseStops, setCourseStops] = useState<CourseStop[]>(mockStops);
@@ -99,7 +103,7 @@ export default function CoursePlannerPage({ skipRoomGuard = false }: CoursePlann
     return <Navigate to="/room" replace />;
   }
 
-  const canGenerate = regionValue.trim().length > 0 && selectedPlaceTypeIds.length > 0;
+  const canGenerate = regionValue.trim().length > 0 && courseOrders.length > 0 && courseOrders.every((order) => order.tags.length > 0);
 
   const handleSelectCity = (city: string) => {
     setDraftCity(city);
@@ -125,13 +129,46 @@ export default function CoursePlannerPage({ skipRoomGuard = false }: CoursePlann
     setMode("form");
   };
 
-  const handleTogglePlaceType = (placeTypeId: PlaceTypeId) => {
-    setSelectedPlaceTypeIds((current) => {
-      if (current.includes(placeTypeId)) {
-        return current.filter((id) => id !== placeTypeId);
-      }
-      return [...current, placeTypeId];
-    });
+  const createOrder = (category: PlaceTypeId): CourseCategoryOrder => ({
+    id: Date.now() + Math.floor(Math.random() * 1000),
+    category,
+    tags: [],
+  });
+
+  const handleCreateFirstOrder = (placeTypeId: PlaceTypeId) => {
+    setCourseOrders([createOrder(placeTypeId)]);
+  };
+
+  const handleAddOrder = () => {
+    setCourseOrders((current) => [...current, createOrder("restaurant")]);
+  };
+
+  const handleSelectOrderCategory = (orderId: number, placeTypeId: PlaceTypeId) => {
+    setCourseOrders((current) =>
+      current.map((order) =>
+        order.id === orderId
+          ? {
+              ...order,
+              category: placeTypeId,
+              tags: [],
+            }
+          : order,
+      ),
+    );
+  };
+
+  const handleToggleOrderTag = (orderId: number, tag: string) => {
+    setCourseOrders((current) =>
+      current.map((order) => {
+        if (order.id !== orderId) return order;
+
+        const hasTag = order.tags.includes(tag);
+        return {
+          ...order,
+          tags: hasTag ? order.tags.filter((item) => item !== tag) : [...order.tags, tag],
+        };
+      }),
+    );
   };
 
   const handleResetPlanner = () => {
@@ -142,7 +179,7 @@ export default function CoursePlannerPage({ skipRoomGuard = false }: CoursePlann
     setDraftDate("2026.04.20");
     setDraftStartTime("13:00");
     setDraftEndTime("21:00");
-    setSelectedPlaceTypeIds(["restaurant"]);
+    setCourseOrders([]);
     setCompletionNoticeVisible(false);
     setMode("form");
   };
@@ -208,11 +245,14 @@ export default function CoursePlannerPage({ skipRoomGuard = false }: CoursePlann
           <CoursePlannerPanel
             regionValue={regionValue}
             dateTimeValue={getDateTimeDisplayValue(dateTimeValue)}
-            selectedPlaceTypeIds={selectedPlaceTypeIds}
+            courseOrders={courseOrders}
             canGenerate={canGenerate}
             onOpenRegionSelect={() => setMode("region")}
             onOpenDateTimeSelect={() => setMode("datetime")}
-            onTogglePlaceType={handleTogglePlaceType}
+            onCreateFirstOrder={handleCreateFirstOrder}
+            onAddOrder={handleAddOrder}
+            onSelectOrderCategory={handleSelectOrderCategory}
+            onToggleOrderTag={handleToggleOrderTag}
             onGenerate={handleGenerateCourse}
             onReset={handleResetPlanner}
           />


### PR DESCRIPTION
## ✨ 무엇을 바꿨나요?

데이트 코스짜기 페이지의 설정 영역 UI를 수정했습니다
기존 장소 종류 선택 대신 데이트 카테고리 및 순서 설정 구조를 추가하고
각 순서별 카테고리와 세부 태그를 선택할 수 있도록 반영했습니다

## 🔗 관련 이슈

Closes #5

## 💡 왜 바꿨나요?

기획 변경에 맞춰 데이트 코스 생성 전에
카테고리와 순서를 더 구체적으로 설정할 수 있도록 화면 구조를 보완하기 위해 수정했습니다

## 📝 주요 변경 사항

- 데이트 코스짜기 설정 영역 UI 변경
- 데이트 카테고리 및 순서 설정 카드 추가
- 순서별 카테고리 선택 UI 추가
- 카테고리별 세부 태그 선택 UI 추가
- 생성 버튼 활성화 조건 조정
- `/dev/course` 미리보기 라우트 타입 오류 수정

## 👀 리뷰어가 보면 좋은 부분

- 기존 course-planner 구조를 유지한 채 변경 범위를 최소화했는지
- 순서 카드 상태 관리 방식
- 카테고리 전환 시 세부 태그 초기화 처리

## 🧪 테스트

- [x] localhost에서 화면 확인
- [ ] 운영 환경에서 확인
- [ ] 단위 / 통합 테스트

## 메모
